### PR TITLE
add option to run airflow upgradedb in init-container

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 7.14.0
+version: 7.15.0
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -58,6 +58,7 @@ kubectl exec \
 > 
 > you can find chart version numbers under [GitHub Releases](https://github.com/airflow-helm/charts/releases)
 
+- [v7.14.X → v7.15.0](UPGRADE.md#v714x--v7150)
 - [v7.13.X → v7.14.0](UPGRADE.md#v713x--v7140)
 - [v7.12.X → v7.13.0](UPGRADE.md#v712x--v7130)
 - [v7.11.X → v7.12.0](UPGRADE.md#v711x--v7120)
@@ -414,12 +415,16 @@ extraManifests:
 
 ---
 
-## Docs (Database) - DB Initialization 
+## Docs (Database) - DB Initialization
 
-If the value `scheduler.initdb` is set to `true` (this is the default), the airflow-scheduler container will run `airflow initdb` as part of its startup script.
+If the value `scheduler.initdb` is set to `true` (this is the default), the airflow-scheduler container will run `airflow upgradedb` as part of its startup script. See `scheduler.upgradedb` for more details.
 
-If the value `scheduler.preinitdb` is set to `true`, then we ALSO RUN `airflow initdb` in an init-container (retrying 5 times).
-This is unusually NOT necessary unless your synced DAGs include custom database hooks that prevent `airflow initdb` from running.
+If the value `scheduler.preinitdb` is set to `true`, then we ALSO RUN `airflow upgradedb` in an init-container (retrying 5 times).
+This is unusually NOT necessary unless your synced DAGs include custom database hooks that prevent `airflow upgradedb` from running.
+
+If the value `scheduler.upgradedb` is set to `true`, `airflow upgradedb` will be run in an init-container. This creates all tables
+needed by airflow without a lot of default connection, charts, etc. which might be prefered over `initdb` for production environments.
+`upgrade` keeps track of migrations already applies, so it’s safe to run as often as you need.
 
 ## Docs (Database) - Passwords
 

--- a/charts/airflow/UPGRADE.md
+++ b/charts/airflow/UPGRADE.md
@@ -1,5 +1,14 @@
 # Upgrading Steps
 
+## `v7.14.X` → `v7.15.0`
+
+__The following values have been ADDED:__
+* `scheduler.upgradedb`
+
+__If you are using `scheduler.initdb` or `scheduler.preintdb`, the behaviour has changed:__
+Instead of running `airflow initdb` these two commands now run `airfow upgradedb`. This command will still create
+all necessary tables but without adding some default values.
+
 ## `v7.13.X` → `v7.14.0`
 
 > ⚠️ WARNING

--- a/charts/airflow/templates/config/configmap-scripts.yaml
+++ b/charts/airflow/templates/config/configmap-scripts.yaml
@@ -38,23 +38,23 @@ data:
     while (( celery inspect --broker $AIRFLOW__CELERY__BROKER_URL --destination celery@$HOSTNAME --json active | python3 -c "import json; active_tasks = json.loads(input())['celery@$HOSTNAME']; print(len(active_tasks))" > 0 )); do
       sleep 10
     done
-  preinit-db.sh: |
+  upgrade-db.sh: |
     #!/bin/bash
     echo "*** Waiting 10s for database"
     sleep 10
 
     COUNT=0
     while [ "${COUNT}" -lt 5 ]; do
-      echo "*** Initializing airflow db"
-      if airflow initdb; then
-        echo "*** Initdb succeeded"
+      echo "*** upgrading airflow db"
+      if airflow upgradedb || airflow db upgrade; then
+        echo "*** upgradedb succeeded"
         exit 0
       else
         ((COUNT++))
-        echo "*** Initdb failed: waiting 5s before retry #${COUNT}"
+        echo "*** upgradedb failed: waiting 5s before retry #${COUNT}"
         sleep 5
       fi
     done
 
-    echo "*** Initdb failed after ${COUNT} retries; failed."
+    echo "*** upgradedb failed after ${COUNT} retries; failed."
     exit 1

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -78,10 +78,10 @@ spec:
         {{- toYaml .Values.scheduler.securityContext | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
-      {{- if or (.Values.dags.initContainer.enabled) (.Values.scheduler.preinitdb) (.Values.scheduler.extraInitContainers) }}
+      {{- if or (.Values.dags.initContainer.enabled) (.Values.scheduler.preinitdb) (.Values.scheduler.extraInitContainers) (.Values.scheduler.upgradedb) }}
       initContainers:
-        {{- if .Values.scheduler.preinitdb }}
-        - name: {{ .Chart.Name }}-preinitdb
+        {{- if or .Values.scheduler.upgradedb .Values.scheduler.preinitdb }}
+        - name: {{ .Chart.Name }}-upgradedb
           image: {{ .Values.airflow.image.repository }}:{{ .Values.airflow.image.tag }}
           imagePullPolicy: {{ .Values.airflow.image.pullPolicy}}
           command:
@@ -90,7 +90,7 @@ spec:
           args:
             - "/bin/bash"
             - "-c"
-            - "/home/airflow/scripts/preinit-db.sh"
+            - "/home/airflow/scripts/upgrade-db.sh"
           envFrom:
             - configMapRef:
                 name: "{{ include "airflow.fullname" . }}-env"
@@ -236,8 +236,8 @@ spec:
                && pip install --user {{ range .Values.airflow.extraPipPackages }} {{ . | quote }} {{ end }} \
               {{- end }}
               {{- if .Values.scheduler.initdb }}
-               && echo "*** executing Airflow initdb..." \
-               && airflow initdb \
+               && echo "*** executing Airflow upgradedb..." \
+               && airflow upgradedb \
               {{- end }}
               {{- if .Values.scheduler.variables }}
                && echo "*** adding Airflow variables..." \

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -315,6 +315,15 @@ scheduler:
   ##
   initdb: true
 
+  ##  if we run `airflow upgradedb` (prior airflow 2.0) or `airflow db upgrade` (> airflow 2.0)
+  ##
+  ## Note:
+  ## - create all the tables required for operation
+  ## - needs an empty DB and anairflow’s user with permission to CREATE/ALTER it
+  ## - upgrade keeps track of migrations already applies, so it’s safe to run as often as you need
+  ## - Do not use airflow initdb as it can create a lot of default connection, charts, etc.
+  upgradedb: false
+
   ## if we run `airflow initdb` inside a special initContainer
   ##
   ## NOTE:


### PR DESCRIPTION
Signed-off-by: Benny Gächter <benny.gaechter@gmail.com>

<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md -->


**What issues does your PR fix?**

None


**What does your PR do?**

Enables the use of `airflow upgradedb` as an init-container which allows airflow state database upgrades and is the prefered method of creating the airflow state database in production environments.


## Checklist
<!-- Place an '[x]' completed tasks -->
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
