### PR TITLE
fix quoting of "$" in connections

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 7.14.2
+version: 7.14.3
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/templates/config/secret-connections.yaml
+++ b/charts/airflow/templates/config/secret-connections.yaml
@@ -15,17 +15,17 @@ stringData:
     #!/usr/bin/env bash
     {{- range .Values.scheduler.connections }}
     {{- if $.Values.scheduler.refreshConnections }}
-    airflow connections --delete --conn_id {{ .id }}
+    airflow connections --delete --conn_id {{ .id | quote | replace `$` `\$` }}
     {{- end }}
-    airflow connections --add --conn_id {{ .id }}
-    {{- if .type }} --conn_type {{ .type | quote }} {{ end -}}
-    {{- if .uri }} --conn_uri {{ .uri | quote }} {{ end -}}
-    {{- if .host }} --conn_host {{ .host | quote }} {{ end -}}
-    {{- if .login }} --conn_login {{ .login | quote }} {{ end -}}
-    {{- if .password }} --conn_password {{ .password | quote }} {{ end -}}
-    {{- if .schema }} --conn_schema {{ .schema | quote }} {{ end -}}
-    {{- if .port }} --conn_port {{ .port }} {{ end -}}
-    {{- if .extra }} --conn_extra {{ ( regexReplaceAll "[\r\n]+" .extra "" ) | quote }} {{ end -}}
+    airflow connections --add --conn_id {{ .id | quote | replace `$` `\$` }}
+    {{- if .type }} --conn_type {{ .type | quote | replace `$` `\$` }} {{ end -}}
+    {{- if .uri }} --conn_uri {{ .uri | quote | replace `$` `\$` }} {{ end -}}
+    {{- if .host }} --conn_host {{ .host | quote | replace `$` `\$` }} {{ end -}}
+    {{- if .login }} --conn_login {{ .login | quote | replace `$` `\$` }} {{ end -}}
+    {{- if .password }} --conn_password {{ .password | quote | replace `$` `\$` }} {{ end -}}
+    {{- if .schema }} --conn_schema {{ .schema | quote | replace `$` `\$` }} {{ end -}}
+    {{- if .port }} --conn_port {{ .port | quote | replace `$` `\$` }} {{ end -}}
+    {{- if .extra }} --conn_extra {{ ( regexReplaceAll "[\r\n]+" .extra "" ) | quote | replace `$` `\$` }} {{ end -}}
     {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md -->


**What issues does your PR fix?**

- fixes #14


**What does your PR do?**

Resolves issue where bash sees `$` as environment variables in connection strings.

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [X] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
