### PR TITLE
Add option to ignore failures for `pip install` when using `installRequirements`

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 7.14.3
+version: 7.15.0
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -659,7 +659,7 @@ airflow:
 
 > ⚠️ if you update the `requirements.txt`, you will have to restart each worker Pod for changes to take effect, you might consider using `airflow.extraPipPackages` instead
 
-We expose the `dags.installRequirements` value to pip install any `requirements.txt` found at the root of your `dags.path` folder as airflow-worker Pods start.
+We expose the `dags.installRequirements` value to pip install any `requirements.txt` found at the root of your `dags.path` folder as airflow-worker Pods start. If you want ignore failures from the `pip install` command, then set `dags.ignoreFailures` to `true`.
 
 ---
 
@@ -801,6 +801,7 @@ __Airflow DAGs Values:__
 | `dags.path` | the airflow dags folder | `/opt/airflow/dags` |
 | `dags.doNotPickle` | whether to disable pickling dags from the scheduler to workers | `false` |
 | `dags.installRequirements` | install any Python `requirements.txt` at the root of `dags.path` automatically | `false` |
+| `dags.ignoreFailures` | ignore failures from installation of Python `requirements.txt`; requires setting `dags.installRequirements` | `false` |
 | `dags.persistence.*` | configs for the dags PVC | `<see values.yaml>` |
 | `dags.git.*` | configs for the DAG git repository & sync container | `<see values.yaml>` |
 | `dags.initContainer.*` | configs for the git-clone container | `<see values.yaml>` |

--- a/charts/airflow/UPGRADE.md
+++ b/charts/airflow/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrading Steps
 
+## `v7.14.X` → `v7.15.0`
+
+__The following value has been ADDED:__
+* `dags.ignoreFailures` - this allows for any non-zero exit codes from the `pip install` command to be ignored; requires `dags.installRequirements` to have been set, otherwise will do nothing.
+
 ## `v7.13.X` → `v7.14.0`
 
 > ⚠️ WARNING

--- a/charts/airflow/templates/config/configmap-scripts.yaml
+++ b/charts/airflow/templates/config/configmap-scripts.yaml
@@ -17,7 +17,7 @@ data:
 
     cd {{ .Values.dags.path | quote }}
     if [ -f requirements.txt ]; then
-      pip install --user -r requirements.txt
+      pip install --user -r requirements.txt {{ if .Values.dags.ignoreFailures }}|| true{{ end }}
     else
       exit 0
     fi

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -885,6 +885,9 @@ dags:
   ##
   installRequirements: false
 
+  ## set to true to ignore failures from `installRequirements`
+  ignoreFailures: false
+
   ## configs for the dags PVC
   ##
   persistence:


### PR DESCRIPTION
**What issues does your PR fix?**

Nothing, adds a feature. In our environment we had some issues where Airflow would go into a crashLoopBackoff when there was an issue installing requirements.txt - this will allow for Airflow to start in such a scenario.

**What does your PR do?**

Adds option to ignore failures from the `install-requirements.sh` script, particularly the `pip install` command.

## Checklist
<!-- Place an '[x]' completed tasks -->
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [x] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
