### PR TITLE
scheduler.variables and scheduler.pools accept dict

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 7.15.0
+version: 7.15.1
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -170,8 +170,8 @@ We expose the `scheduler.variables` value to specify [Airflow Variables](https:/
 For example, to specify a variable called `environment`:
 ```yaml
 scheduler:
-  variables: |
-    { "environment": "dev" }
+  variables:
+    environment: "dev"
 ```
 
 ## Docs (Airflow) - Pools

--- a/charts/airflow/templates/config/configmap-variables-pools.yaml
+++ b/charts/airflow/templates/config/configmap-variables-pools.yaml
@@ -11,10 +11,18 @@ metadata:
 data:
   {{- if .Values.scheduler.variables }}
   variables.json: |
-    {{- .Values.scheduler.variables | nindent 4 }}
+    {{- if eq (typeOf .Values.scheduler.variables) "map[string]interface {}" }}
+      {{- (default .Values.scheduler.variables (.Values.scheduler.variables | toPrettyJson)) | nindent 4 }}
+    {{- else if eq (typeOf .Values.scheduler.variables) "string" }}
+      {{- .Values.scheduler.variables | nindent 4 }}
+    {{- end }}
   {{- end }}
   {{- if .Values.scheduler.pools }}
   pools.json: |
-    {{- .Values.scheduler.pools | nindent 4 }}
+    {{- if eq (typeOf .Values.scheduler.pools) "map[string]interface {}" }}
+      {{- (default .Values.scheduler.pools (.Values.scheduler.pools | toPrettyJson)) | nindent 4 }}
+    {{- else if eq (typeOf .Values.scheduler.variables) "string" }}
+      {{- .Values.scheduler.pools | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -280,9 +280,13 @@ scheduler:
   ## NOTE:
   ## - THIS IS A STRING, containing a JSON object, with your variables in it
   ##
-  ## EXAMPLE:
+  ## EXAMPLE_STRING:
   ##   variables: |
   ##     { "environment": "dev" }
+  ##
+  ## EXAMPLE_DICT:
+  ##   variables:
+  ##     environment: dev
   ##
   variables: |
     {}
@@ -290,9 +294,9 @@ scheduler:
   ## custom airflow pools for the airflow scheduler
   ##
   ## NOTE:
-  ## - THIS IS A STRING, containing a JSON object, with your pools in it
+  ## - This can be a dict or a string, containing a JSON object, with your pools in it
   ##
-  ## EXAMPLE:
+  ## EXAMPLE_STRING:
   ##   pools: |
   ##     {
   ##       "example": {
@@ -300,6 +304,14 @@ scheduler:
   ##         "slots": 2
   ##       }
   ##     }
+  ##
+  ## EXAMPLE_DICT:
+  ##   pools:
+  ##     example: {
+  ##       description: This is an example pool with 2 slots.
+  ##       slots: 2
+  ##     }
+  ##   }
   ##
   pools: |
     {}


### PR DESCRIPTION
Signed-off-by: Mathieu Thoretton <mathieu.thoretton@tiko.energy>

**What does your PR do?**

It allows `scheduler.variables` and `scheduler.pools` variables to accept dictionaries, along with strings.
I tried locally, it works and do not bring any breaking change or different behaviour.
This would be very handy in order to override or extend the variables in the context of multiple environements and instances.

## Checklist
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [x] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
