### PR TITLE
Add keda autoscaler support

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 7.15.0
+version: 7.16.0
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -297,6 +297,8 @@ ingress:
 
 ## Docs (Kubernetes) - Worker Autoscaling
 
+### Option 1: Horizontal Pod Autoscaler
+
 We use a Kubernetes StatefulSet for the Celery workers, this allows the webserver to requests logs from each workers individually, with a fixed DNS name.
 
 Celery workers can be scaled using the [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/).
@@ -353,6 +355,29 @@ dags:
           ## IMPORTANT! for autoscaling to work
           memory: "64Mi"
 ```
+
+### Option 2: KEDA autoscaler
+
+First install KEDA:
+
+```bash
+helm install keda \
+    --namespace keda kedacore/keda \
+    --version "v2.0.0"
+```
+
+Next, enable:
+
+```yaml
+workers:
+  keda:
+    enabled: true 
+  persistence:
+    enabled: false  # required for KEDA
+```
+
+Enabling keda will trigger the creation of a `ScaledObject` custom resource and an associated `hpa`.
+
 
 ## Docs (Kubernetes) - Worker Secrets
 

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -358,17 +358,11 @@ dags:
 
 ### Option 2: KEDA autoscaler
 
-First install KEDA:
-
-```bash
-helm install keda \
-    --namespace keda kedacore/keda \
-    --version "v2.0.0"
-```
-
-Next, enable:
+To enable, ensure these values are set:
 
 ```yaml
+airflow:
+  executor: CeleryExecutor  # or CeleryKubernetesExecutor
 workers:
   keda:
     enabled: true 
@@ -376,8 +370,16 @@ workers:
     enabled: false  # required for KEDA
 ```
 
-Enabling keda will trigger the creation of a `ScaledObject` custom resource and an associated `hpa`.
+KEDA will autoscale the number of celery workers based on the following query:
 
+```sql
+SELECT ceil(COUNT(*)::decimal / 16)
+FROM task_instance
+WHERE state='running'
+    OR state='queued'"
+```
+
+See `templates/worker/keda-autoscaler.yaml` for more info.
 
 ## Docs (Kubernetes) - Worker Secrets
 

--- a/charts/airflow/requirements.lock
+++ b/charts/airflow/requirements.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: redis
   repository: https://charts.helm.sh/stable
   version: 10.5.7
-digest: sha256:bfe30fcaf72a0609856bf1a5dab2b941e8ef89b30ba935aa820743a6758f4fc4
-generated: "2020-11-05T16:33:27.586085+11:00"
+- name: keda
+  repository: https://kedacore.github.io/charts
+  version: 2.0.0
+digest: sha256:ab895cc32b8de0dc24f3e8cff193d5e283269acb87ff2e2cdc2069e83578ebf6
+generated: "2020-12-19T18:30:40.668812-08:00"

--- a/charts/airflow/requirements.yaml
+++ b/charts/airflow/requirements.yaml
@@ -7,3 +7,9 @@ dependencies:
   version: 10.5.7
   repository: https://charts.helm.sh/stable
   condition: redis.enabled
+- name: keda
+  version: 2.0.0
+  repository: https://kedacore.github.io/charts
+  condition: workers.keda.enabled
+  tags:
+    - keda

--- a/charts/airflow/templates/worker/keda-autoscaler.yaml
+++ b/charts/airflow/templates/worker/keda-autoscaler.yaml
@@ -17,9 +17,9 @@ spec:
   scaleTargetRef:
     kind: StatefulSet
     name: {{ include "airflow.fullname" . }}-worker
-  pollingInterval:  {{ .Values.workers.keda.pollingInterval }}   # Optional. Default: 30 seconds
-  cooldownPeriod: {{ .Values.workers.keda.cooldownPeriod }}    # Optional. Default: 300 seconds
-  maxReplicaCount: {{ .Values.workers.keda.maxReplicaCount }}   # Optional. Default: 100
+  pollingInterval:  {{ .Values.workers.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.workers.keda.cooldownPeriod }}
+  maxReplicaCount: {{ .Values.workers.keda.maxReplicaCount }}
   triggers:
     - type: postgresql
       metadata:

--- a/charts/airflow/templates/worker/keda-autoscaler.yaml
+++ b/charts/airflow/templates/worker/keda-autoscaler.yaml
@@ -21,14 +21,23 @@ spec:
   cooldownPeriod: {{ .Values.workers.keda.cooldownPeriod }}
   maxReplicaCount: {{ .Values.workers.keda.maxReplicaCount }}
   triggers:
-    - type: postgresql
+    - type: "{{ ternary "mysql" "postgresql" (eq .Values.externalDatabase.type "mysql") }}"
       metadata:
         targetQueryValue: "1"
-        userName: {{ .Values.postgresql.postgresqlUsername }}
+        {{- if .Values.postgresql.enabled }}
         host: {{ include "airflow.postgresql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
-        dbName: {{ .Values.postgresql.postgresqlDatabase }}
         port: "5432"
-        sslmode: disable
+        userName: "{{ .Values.postgresql.postgresqlUsername }}"
+        dbName: "{{ .Values.postgresql.postgresqlDatabase }}"
+        {{- else }}
+        host: "{{ .Values.externalDatabase.host }}"
+        port: "{{ .Values.externalDatabase.port }}"
+        userName: "{{ .Values.externalDatabase.user }}"
+        dbName: "{{ .Values.externalDatabase.database }}"
+        {{- end }}
+        sslmode: {{ .Values.workers.keda.sslmode }}
         passwordFromEnv: DATABASE_PASSWORD
-        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+        query: >-
+          SELECT ceil({{- ternary "count(*)" "count(*)::decimal" (eq .Values.externalDatabase.type "mysql") -}} / 16)
+          FROM task_instance WHERE state='running' OR state='queued'
 {{- end }}

--- a/charts/airflow/templates/worker/keda-autoscaler.yaml
+++ b/charts/airflow/templates/worker/keda-autoscaler.yaml
@@ -1,0 +1,34 @@
+{{- if (and .Values.workers.keda.enabled ( or (eq .Values.airflow.executor "CeleryExecutor") (eq .Values.airflow.executor "CeleryKubernetesExecutor"))) }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ .Release.Name }}-worker
+  labels:
+    tier: airflow
+    component: worker-horizontalpodautoscaler
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    deploymentName: {{ .Release.Name }}-worker
+{{- with .Values.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  scaleTargetRef:
+    kind: StatefulSet
+    name: {{ include "airflow.fullname" . }}-worker
+  pollingInterval:  {{ .Values.workers.keda.pollingInterval }}   # Optional. Default: 30 seconds
+  cooldownPeriod: {{ .Values.workers.keda.cooldownPeriod }}    # Optional. Default: 300 seconds
+  maxReplicaCount: {{ .Values.workers.keda.maxReplicaCount }}   # Optional. Default: 100
+  triggers:
+    - type: postgresql
+      metadata:
+        targetQueryValue: "1"
+        userName: {{ .Values.postgresql.postgresqlUsername }}
+        host: {{ include "airflow.postgresql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+        dbName: {{ .Values.postgresql.postgresqlDatabase }}
+        port: "5432"
+        sslmode: disable
+        passwordFromEnv: DATABASE_PASSWORD
+        query: "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance WHERE state='running' OR state='queued'"
+{{- end }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -621,6 +621,13 @@ workers:
     maxReplicas: 2
     metrics: []
 
+
+  keda:
+    enabled: false
+    pollingInterval: 30
+    cooldownPeriod: 300
+    maxReplicaCount: 100
+
   ## the number of seconds to wait (in bash) before starting each worker container
   ##
   initialStartupDelay: 0

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -627,6 +627,7 @@ workers:
     pollingInterval: 30
     cooldownPeriod: 300
     maxReplicaCount: 100
+    sslmode: ""
 
   ## the number of seconds to wait (in bash) before starting each worker container
   ##


### PR DESCRIPTION
**What does your PR do?**

This PR adds support for KEDA.

KEDA v2.0.0 allows scaling of StatefulSets, which makes it compatible with this helm chart.

Ther are two things that I'd like to call to your attention.

**Creds logic for the ScaledObject**

I had some trouble finding a good way to use existing config structure and allow local postgres, external db, and connection properties but I think I worked out a decent solution.

The first issue was that currently the chart expects urlencoded database properties like `&sslmode=disable` This assumes we'll use a URI for all database connections.

So I tried to use URI format for ScaledObject.

But I found there is no way to assemble the full connection URI, because the chart assumes the password comes from a secret independently (as opposed to a secret containing full URI).   And apparently you can't really concat env vars that come from secrets in the helm chart (which I guess is why the chart uses the _CMD env vars, but this won't work with the ScaledObject definiton).  So, this forces me to provide the database params individually (as opposed to URI).  Which brings back to the first problem -- the properties are given as urlencoded params.

But so my solution was to simply add sslmode as optional config under `workers.keda`; this is the only extra param available within postgres trigger, and in mysql there are no extra params.

It would be safer to use URI secret because user has full control and template doesn't need to worry about the logic.  But that's inconsistent with the chart.

Anyway, guidance on this would be appreciated.

**Inclusion of KEDA as dependency**

I did not add keda as dependency initially.   Initially I assumed you would install keda independently.

On the one hand it is desirable to install the keda components independently, so that it could be used with multiple airflow instances in the same cluster.

On the other hand, including keda as a dependency simplifies installation.

A third option would be to specify `keda` namespace for the keda components, which would just require that the user create a keda namespace (i _think_ this is possible).  Feedback on this one appreciated as well.

Thanks