### PR TITLE
scheduler bash script new

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 7.15.0
+version: 7.15.1
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -53,6 +53,7 @@ airflow create_user ...
 
 Find chart version numbers under [GitHub Releases](https://github.com/airflow-helm/charts/releases):
 
+- [v7.15.0 → v7.15.1](UPGRADE.md#v7150--v7151)
 - [v7.14.X → v7.15.0](UPGRADE.md#v714x--v7150)
 - [v7.13.X → v7.14.0](UPGRADE.md#v713x--v7140)
 - [v7.12.X → v7.13.0](UPGRADE.md#v712x--v7130)

--- a/charts/airflow/UPGRADE.md
+++ b/charts/airflow/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrading Steps
 
+## `v7.15.0` → `v7.15.1`
+
+__The following IMPROVEMENTS have been made:__
+* We now use `airflow variables -i /home/airflow/variables-pools/variables.json || airflow variables import /home/airflow/variables-pools/variables.json` instead of `airflow variables -i /home/airflow/variables-pools/variables.json`
+* We now use `airflow pool -i /home/airflow/variables-pools/pools.json || airflow pools import /home/airflow/variables-pools/pools.json` instead of `airflow pool -i /home/airflow/variables-pools/pools.json`
+   
+
 ## `v7.14.X` → `v7.15.0`
 
 __The following IMPROVEMENTS have been made:__

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -241,7 +241,7 @@ spec:
               {{- end }}
               {{- if .Values.scheduler.variables }}
                && echo "*** adding Airflow variables..." \
-               && airflow variables -i /home/airflow/variables-pools/variables.json \
+               && airflow variables -i /home/airflow/variables-pools/variables.json || airflow variables import /home/airflow/variables-pools/variables.json \
               {{- end }}
               {{- if or (.Values.scheduler.connections) (.Values.scheduler.existingSecretConnections) }}
                && echo "*** adding Airflow connections..." \
@@ -249,7 +249,7 @@ spec:
               {{- end }}
               {{- if .Values.scheduler.pools }}
                && echo "*** adding Airflow pools..." \
-               && airflow pool -i /home/airflow/variables-pools/pools.json \
+               && airflow pool -i /home/airflow/variables-pools/pools.json || airflow pools import /home/airflow/variables-pools/pools.json \
               {{- end }}
                && echo "*** running scheduler..." \
                && exec airflow scheduler -n {{ .Values.scheduler.numRuns }}


### PR DESCRIPTION
Signed-off-by: aseficha <aseficha@gmail.com>


**What does your PR do?**

add support for running the scheduler initialisation bash command for the new airflow variables and pools command syntax. In Airflow 2.0 the commands have been changed to `airflow variables import ` instead of `airflow variables -i ` and `airflow pools import` instead of `airflow pool -i`

## Checklist
<!-- Place an '[x]' completed tasks -->
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [x] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
