### PR TITLE
scheduler kubernetes secrets

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 7.15.0
+version: 7.16.0
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -53,6 +53,7 @@ airflow create_user ...
 
 Find chart version numbers under [GitHub Releases](https://github.com/airflow-helm/charts/releases):
 
+- [v7.15.X → v7.16.0](UPGRADE.md#v715x--v7160)
 - [v7.14.X → v7.15.0](UPGRADE.md#v714x--v7150)
 - [v7.13.X → v7.14.0](UPGRADE.md#v713x--v7140)
 - [v7.12.X → v7.13.0](UPGRADE.md#v712x--v7130)
@@ -712,6 +713,9 @@ __Airflow Scheduler values:__
 | `scheduler.preinitdb` | if we run `airflow upgradedb` inside a special initContainer | `false` |
 | `scheduler.initialStartupDelay` | the number of seconds to wait (in bash) before starting the scheduler container | `0` |
 | `scheduler.livenessProbe.*` | configs for the scheduler liveness probe | `<see values.yaml>` |
+| `scheduler.secretsDir` | the directory in which to mount secrets on scheduler containers | `/var/airflow/secrets` |
+| `scheduler.secrets` | the names of existing Kubernetes Secrets to mount as files at `{workers.secretsDir}/<secret_name>/<keys_in_secret>` | `[]` |
+| `scheduler.secretsMap` | the name of an existing Kubernetes Secret to mount as files to `{web.secretsDir}/<keys_in_secret>` | `""` |
 | `scheduler.extraInitContainers` | extra init containers to run before the scheduler pod | `[]` |
 
 __Airflow Webserver Values:__

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -181,6 +181,17 @@ spec:
           volumeMounts:
             - name: scripts
               mountPath: /home/airflow/scripts
+            {{- if .Values.scheduler.secretsMap }}
+            - name: {{ .Values.scheduler.secretsMap }}-volume
+              readOnly: true
+              mountPath: {{ $.Values.scheduler.secretsDir }}
+            {{- else }}
+            {{- range .Values.scheduler.secrets }}
+            - name: {{ . }}-volume
+              readOnly: true
+              mountPath: {{ $.Values.scheduler.secretsDir }}/{{ . }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.dags.persistence.enabled }}
             - name: dags-data
               mountPath: {{ .Values.dags.path }}
@@ -281,6 +292,17 @@ spec:
           configMap:
             name: {{ include "airflow.fullname" . }}-scripts
             defaultMode: 0755
+        {{- if .Values.scheduler.secretsMap }}
+        - name: {{ .Values.scheduler.secretsMap }}-volume
+          secret:
+            secretName: {{ .Values.scheduler.secretsMap }}
+        {{- else }}
+        {{- range .Values.scheduler.secrets }}
+        - name: {{ . }}-volume
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.dags.persistence.enabled }}
         - name: dags-data
           persistentVolumeClaim:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -346,6 +346,21 @@ scheduler:
     periodSeconds: 30
     failureThreshold: 5
 
+  ## the directory in which to mount secrets on scheduler containers
+  ##
+  secretsDir: /var/airflow/secrets
+
+  ## the names of existing Kubernetes Secrets to mount as files at `{workers.secretsDir}/<secret_name>/<keys_in_secret>`
+  ##
+  secrets: []
+
+  ## the name of an existing Kubernetes Secret to mount as files to `{web.secretsDir}/<keys_in_secret>`
+  ##
+  ## NOTE:
+  ##  - overrides `scheduler.secrets`
+  ##
+  secretsMap: ""
+
   ## extra init containers to run before the scheduler Pod
   ##
   ## EXAMPLE:


### PR DESCRIPTION
Signed-off-by: lidor ettinger <lidor.ettinger@gmail.com>

<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md -->

**What does your PR do?**
In the same way as we can add secrets for web and workers we would like to do also for scheduler.
This PR provides a way to add a credential for a local repository, such as nexus, in order to download its dependencies.

## Checklist
<!-- Place an '[x]' completed tasks -->
- [ ] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [ ] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [ ] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [ ] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
