### PR TITLE
Add extra start command on webserver deployment

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 7.16.0
+version: 7.17.0
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -738,6 +738,7 @@ __Airflow Webserver Values:__
 | `web.baseUrl` | sets `AIRFLOW__WEBSERVER__BASE_URL` | `http://localhost:8080` |
 | `web.serializeDAGs` | sets `AIRFLOW__CORE__STORE_SERIALIZED_DAGS` | `false` |
 | `web.extraPipPackages` | extra pip packages to install in the web container | `[]` |
+| `web.extraStartCommand` | extra command/script to execute as user `airflow` before starting webserver | `[]` |
 | `web.initialStartupDelay` | the number of seconds to wait (in bash) before starting the web container | `0` |
 | `web.minReadySeconds` | the number of seconds to wait before declaring a new Pod available | `5` |
 | `web.readinessProbe.*` | configs for the web Service readiness probe | `<see values.yaml>` |

--- a/charts/airflow/examples/google-gke/custom-values.yaml
+++ b/charts/airflow/examples/google-gke/custom-values.yaml
@@ -173,6 +173,10 @@ web:
   ##
   extraPipPackages: []
 
+  ## extra command/script to execute as user `airflow` before starting webserver
+  ##
+  extraStartCommand: []
+
   ## configs for the web Service liveness probe
   ##
   livenessProbe:

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -218,6 +218,11 @@ spec:
                && echo "*** installing extra pip packages..." \
                && pip install --user {{ range .Values.web.extraPipPackages }} {{ . | quote }} {{ end }} \
               {{- end }}
+              {{- if .Values.web.extraStartCommand }}
+              {{- range .Values.web.extraStartCommand }} 
+               && {{ . }} \ 
+              {{- end }}
+              {{- end }}
                && echo "*** running webserver..." \
                && exec airflow webserver
           {{- if .Values.web.livenessProbe.enabled }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -483,6 +483,15 @@ web:
   ##
   extraPipPackages: []
 
+  ## extra command/script to execute as user `airflow` before starting webserver
+  ## also can be used to execute script mounted from `airflow.extraVolumeMounts`
+  ## EXAMPLE:
+  ##   extraStartCommand:
+  ##     - "sed "s/localhost:8000/$ENV_DOMAIN/g" /opt/airflow/dags/script.py"
+  ##     - /home/airflow/setup-credentials.sh
+  ##
+  extraStartCommand: []
+
   ## the number of seconds to wait (in bash) before starting the web container
   ##
   initialStartupDelay: 0


### PR DESCRIPTION
Signed-off-by: abrahamgv <abgav3011@gmail.com>

**What does your PR do?**

Allow user to execute extra start command/script before starting the webserver. Due to docker image started as user `airflow`, the command/script is limited to `airflow` user permission. User can put shell command as values or else just execute script that mounted from `airflow.extraVolumeMounts`

## Checklist
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [x] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
