### PR TITLE
LDAP example and more accurate volume mount hack

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 7.16.0
+version: 7.17.0
 appVersion: 1.10.12
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -63,6 +63,10 @@ airflow:
   ##     AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "False"
   ##     AIRFLOW__WEBSERVER__RBAC: "False"
   ##
+  ##     ## Security (using LDAP)
+  ##     AIRFLOW__WEBSERVER__AUTHENTICATE: "True"
+  ##     AIRFLOW__WEBSERVER__AUTH_BACKEND: "airflow.contrib.auth.backends.ldap_auth"
+  ##
   ##     ## DAGS
   ##     AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL: "30"
   ##     AIRFLOW__CORE__LOAD_EXAMPLES: "False"
@@ -74,6 +78,18 @@ airflow:
   ##     AIRFLOW__SMTP__SMTP_SSL: "False"
   ##     AIRFLOW__SMTP__SMTP_PORT: "25"
   ##     AIRFLOW__SMTP__SMTP_MAIL_FROM: "admin@example.com"
+  ##
+  ##     ## LDAP
+  ##     AIRFLOW__LDAP__URI: "ldaps://ldap.example.com:636"
+  ##     AIRFLOW__LDAP__USER_FILTER: "objectClass=*"
+  ##     AIRFLOW__LDAP__USER_NAME_ATTR: "sAMAccountName"
+  ##     AIRFLOW__LDAP__GROUP_MEMBER_ATTR: "memberOf"
+  ##     AIRFLOW__LDAP__GROUP_NAME_ATTR: "cn"
+  ##     AIRFLOW__LDAP__SUPERUSER_FILTER: "memberOf=cn=admins,ou=groups,dc=example,dc=com"
+  ##     AIRFLOW__LDAP__DATA_PROFILER_FILTER: "memberOf=cn=data_profiler,ou=groups,dc=example,dc=co"
+  ##     AIRFLOW__LDAP__BASEDN: "dc=example,dc=com"
+  ##     AIRFLOW__LDAP__SEARCH_SCOPE: "SUBTREE"
+  ##     AIRFLOW__LDAP__CACERT: "/etc/ca/ldap_ca.crt"
   ##
   ##     ## Disable noisy "Handling signal: ttou" Gunicorn log messages
   ##     GUNICORN_CMD_ARGS: "--log-level WARNING"
@@ -104,7 +120,12 @@ airflow:
   ##       valueFrom:
   ##         secretKeyRef:
   ##           name: airflow-ldap-password
-  ##           key: value
+  ##           key: password
+  ##     - name: AIRFLOW__LDAP__BIND_USER
+  ##       valueFrom:
+  ##         secretKeyRef:
+  ##           name: airflow-ldap-secret
+  ##           key: bind_dn
   ##
   extraEnv: []
 
@@ -367,9 +388,9 @@ scheduler:
   ##   extraInitContainers:
   ##     - name: volume-mount-hack
   ##       image: busybox
-  ##       command: ["sh", "-c", "chown -R 1000:1000 logs"]
+  ##       command: ["sh", "-c", "chown -R 50000:50000 /logs"]
   ##       volumeMounts:
-  ##         - mountPath: /opt/airflow/logs
+  ##         - mountPath: /logs
   ##           name: logs-data
   ##
   extraInitContainers: []


### PR DESCRIPTION
I think it would be useful to add an example ldap config. I had to do quite a bot of digging to find something that worked. A simple example can at least get a user pointed in the right direction. I also changed the volume mount hack to be a better example. The aiflow uid/gid is 50000, so it seems logical to have a sample that matches.

<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md -->


**What issues does your PR fix?**

- fixes values.yaml
- fixes #YYY


**What does your PR do?**

Adds an LDAP example to the values.yaml file. Added a more accurate and usable volume mount hack.


## Checklist
<!-- Place an '[x]' completed tasks -->
- [ ] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [ ] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [x] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [ ] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
