### PR TITLE
Improve _helpers.tpl with airflow.fullname and airflow.name

### DIFF
--- a/charts/airflow/templates/_helpers.tpl
+++ b/charts/airflow/templates/_helpers.tpl
@@ -1,11 +1,28 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-Construct the base name for all resources in this chart.
+Expand the name of the chart.
+*/}}
+{{- define "airflow.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "airflow.fullname" -}}
-{{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md -->


**What issues does your PR fix?**

While using ArgoCD to manage a cluster the Helm Release Name becomes the Application name, in many cases people use application name with prefixes and suffixes that allow them to better identify their ArgoCD resources.
Example
ArgoCD application with name Airflow-{USERNAME} would create airflow-web-{USERNAME} which might not be the wanted resource. In order to avoid this issue, fullnameOverride helm paramenter is often used to force these resources to have the wanted naming.

**What does your PR do?**

Allow the use of fullnameOverride helm parameter in order to better name resources.

## Checklist
<!-- Place an '[x]' completed tasks -->
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [ ] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [ ] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
