### PR TITLE
toYaml needs whitespace

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.0.1
+version: 8.0.2
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -189,12 +189,12 @@ EXAMPLE USAGE: {{ include "airflow.volumeMounts" (dict "Values" .Values "extraPi
 
 {{- /* user-defined (global) */ -}}
 {{- if .Values.airflow.extraVolumeMounts }}
-{{- toYaml .Values.airflow.extraVolumeMounts }}
+{{ toYaml .Values.airflow.extraVolumeMounts }}
 {{- end }}
 
 {{- /* user-defined */ -}}
 {{- if .extraVolumeMounts }}
-{{- toYaml .extraVolumeMounts }}
+{{ toYaml .extraVolumeMounts }}
 {{- end }}
 {{- end }}
 
@@ -248,12 +248,12 @@ EXAMPLE USAGE: {{ include "airflow.volumes" (dict "Values" .Values "extraPipPack
 
 {{- /* user-defined (global) */ -}}
 {{- if .Values.airflow.extraVolumes }}
-{{- toYaml .Values.airflow.extraVolumes }}
+{{ toYaml .Values.airflow.extraVolumes }}
 {{- end }}
 
 {{- /* user-defined */ -}}
 {{- if .extraVolumes }}
-{{- toYaml .extraVolumes }}
+{{ toYaml .extraVolumes }}
 {{- end }}
 {{- end }}
 

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -154,12 +154,12 @@ spec:
           {{- $volumeMounts := include "airflow.volumeMounts" (dict "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
           {{- if $volumeMounts }}
           volumeMounts:
-            {{- $volumeMounts | nindent 12 }}
+            {{- $volumeMounts | indent 12 }}
           {{- end }}
       {{- $extraVolumes := .Values.flower.extraVolumes }}
       {{- $volumes := include "airflow.volumes" (dict "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
       {{- if $volumes }}
       volumes:
-        {{- $volumes | nindent 8 }}
+        {{- $volumes | indent 8 }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: benrifkind <ben.rifkind@gmail.com>

<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md -->


**What issues does your PR fix?**

- fixes #101 


**What does your PR do?**

Whitespace was being trimmed by this helper function which resulted in the line being squashed. This also removes the `nindent` which was added in #102 ostensibly to fix this issue.


## Checklist
<!-- Place an '[x]' completed tasks -->
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [x] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
