### PR TITLE
release 8.0.2

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.0.1
+version: 8.0.2
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -45,6 +45,10 @@ spec:
         - configMapRef:
             name: "{{ include "airflow.fullname" . }}-env"
       env:
+        {{- if $extraPipPackages }}
+        - name: PYTHONPATH
+          value: /opt/python/site-packages
+        {{- end }}
         {{- include "airflow.env" . | indent 8 }}
         - name: AIRFLOW__CORE__EXECUTOR
           value: LocalExecutor
@@ -55,11 +59,11 @@ spec:
       {{- $volumeMounts := include "airflow.volumeMounts" (dict "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
       {{- if $volumeMounts }}
       volumeMounts:
-        {{- $volumeMounts | nindent 8 }}
+        {{- $volumeMounts | indent 8 }}
       {{- end }}
   {{- $extraVolumes := .Values.airflow.kubernetesPodTemplate.extraVolumes }}
   {{- $volumes := include "airflow.volumes" (dict "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
   {{- if $volumes }}
   volumes:
-    {{- $volumes | nindent 4 }}
+    {{- $volumes | indent 4 }}
   {{- end }}

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -189,12 +189,12 @@ EXAMPLE USAGE: {{ include "airflow.volumeMounts" (dict "Values" .Values "extraPi
 
 {{- /* user-defined (global) */ -}}
 {{- if .Values.airflow.extraVolumeMounts }}
-{{- toYaml .Values.airflow.extraVolumeMounts }}
+{{ toYaml .Values.airflow.extraVolumeMounts }}
 {{- end }}
 
 {{- /* user-defined */ -}}
 {{- if .extraVolumeMounts }}
-{{- toYaml .extraVolumeMounts }}
+{{ toYaml .extraVolumeMounts }}
 {{- end }}
 {{- end }}
 
@@ -248,12 +248,12 @@ EXAMPLE USAGE: {{ include "airflow.volumes" (dict "Values" .Values "extraPipPack
 
 {{- /* user-defined (global) */ -}}
 {{- if .Values.airflow.extraVolumes }}
-{{- toYaml .Values.airflow.extraVolumes }}
+{{ toYaml .Values.airflow.extraVolumes }}
 {{- end }}
 
 {{- /* user-defined */ -}}
 {{- if .extraVolumes }}
-{{- toYaml .extraVolumes }}
+{{ toYaml .extraVolumes }}
 {{- end }}
 {{- end }}
 

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -35,7 +35,7 @@
   {{ required "Don't define `airflow.config.AIRFLOW__CORE__EXECUTOR`, it will be automatically set by the chart!" nil }}
 {{- end }}
 {{- if or .Values.airflow.config.AIRFLOW__CORE__DAGS_FOLDER }}
-  {{ required "Don't define `airflow.config.AIRFLOW__CORE__EXECUTOR`, it will be automatically set by the chart!" nil }}
+  {{ required "Don't define `airflow.config.AIRFLOW__CORE__DAGS_FOLDER`, it will be automatically set by the chart!" nil }}
 {{- end }}
 {{- if or (.Values.airflow.config.AIRFLOW__CELERY__BROKER_URL) (.Values.airflow.config.AIRFLOW__CELERY__BROKER_URL_CMD) }}
   {{ required "Don't define `airflow.config.AIRFLOW__CELERY__BROKER_URL`, it will be automatically set by the chart!" nil }}

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -87,11 +87,11 @@ spec:
           envFrom:
             {{- include "airflow.envFrom" . | indent 12 }}
           env:
-            {{- include "airflow.env" . | indent 12 }}
             {{- if $extraPipPackages }}
             - name: PYTHONPATH
               value: /opt/python/site-packages
             {{- end }}
+            {{- include "airflow.env" . | indent 12 }}
             {{- if .Values.flower.basicAuthSecret }}
             - name: AIRFLOW__CELERY__FLOWER_BASIC_AUTH
               valueFrom:
@@ -154,12 +154,12 @@ spec:
           {{- $volumeMounts := include "airflow.volumeMounts" (dict "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
           {{- if $volumeMounts }}
           volumeMounts:
-            {{- $volumeMounts | nindent 12 }}
+            {{- $volumeMounts | indent 12 }}
           {{- end }}
       {{- $extraVolumes := .Values.flower.extraVolumes }}
       {{- $volumes := include "airflow.volumes" (dict "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
       {{- if $volumes }}
       volumes:
-        {{- $volumes | nindent 8 }}
+        {{- $volumes | indent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -90,11 +90,11 @@ spec:
           envFrom:
             {{- include "airflow.envFrom" . | indent 12 }}
           env:
-            {{- include "airflow.env" . | indent 12 }}
             {{- if $extraPipPackages }}
             - name: PYTHONPATH
               value: /opt/python/site-packages
             {{- end }}
+            {{- include "airflow.env" . | indent 12 }}
           command:
             - "/usr/bin/dumb-init"
             - "--"
@@ -141,7 +141,7 @@ spec:
           {{- $volumeMounts := include "airflow.volumeMounts" (dict "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
           {{- if or ($volumeMounts) (include "airflow.executor.kubernetes_like" .) }}
           volumeMounts:
-            {{- $volumeMounts | nindent 12 }}
+            {{- $volumeMounts | indent 12 }}
             {{- if include "airflow.executor.kubernetes_like" . }}
             - name: pod-template
               mountPath: /opt/airflow/pod_templates/pod_template.yaml
@@ -159,7 +159,7 @@ spec:
       {{- $volumes := include "airflow.volumes" (dict "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
       {{- if or ($volumes) (include "airflow.executor.kubernetes_like" .) }}
       volumes:
-        {{- $volumes | nindent 8 }}
+        {{- $volumes | indent 8 }}
         {{- if include "airflow.executor.kubernetes_like" . }}
         - name: pod-template
           configMap:

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -91,11 +91,11 @@ spec:
           envFrom:
             {{- include "airflow.envFrom" . | indent 12 }}
           env:
-            {{- include "airflow.env" . | indent 12 }}
             {{- if $extraPipPackages }}
             - name: PYTHONPATH
               value: /opt/python/site-packages
             {{- end }}
+            {{- include "airflow.env" . | indent 12 }}
           command:
             - "/usr/bin/dumb-init"
             - "--"
@@ -128,7 +128,7 @@ spec:
           {{- $extraVolumeMounts := .Values.web.extraVolumeMounts }}
           {{- $volumeMounts := include "airflow.volumeMounts" (dict "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
           volumeMounts:
-            {{- $volumeMounts | nindent 12 }}
+            {{- $volumeMounts | indent 12 }}
             - name: webserver-config
               mountPath: /opt/airflow/webserver_config.py
               subPath: webserver_config.py
@@ -142,7 +142,7 @@ spec:
       {{- $extraVolumes := .Values.web.extraVolumes }}
       {{- $volumes := include "airflow.volumes" (dict "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
       volumes:
-        {{- $volumes | nindent 8 }}
+        {{- $volumes | indent 8 }}
         - name: webserver-config
           secret:
             {{- if .Values.web.webserverConfig.existingSecret }}

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -92,11 +92,11 @@ spec:
           envFrom:
             {{- include "airflow.envFrom" . | indent 12 }}
           env:
-            {{- include "airflow.env" . | indent 12 }}
             {{- if $extraPipPackages }}
             - name: PYTHONPATH
               value: /opt/python/site-packages
             {{- end }}
+            {{- include "airflow.env" . | indent 12 }}
           {{- if .Values.workers.celery.gracefullTermination }}
           lifecycle:
             preStop:
@@ -158,7 +158,7 @@ spec:
           {{- $volumeMounts := include "airflow.volumeMounts" (dict "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
           {{- if $volumeMounts }}
           volumeMounts:
-            {{- $volumeMounts | nindent 12 }}
+            {{- $volumeMounts | indent 12 }}
           {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
         {{- include "airflow.container.git_sync" . | indent 8 }}
@@ -170,6 +170,6 @@ spec:
       {{- $volumes := include "airflow.volumes" (dict "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
       {{- if $volumes }}
       volumes:
-        {{- $volumes | nindent 8 }}
+        {{- $volumes | indent 8 }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
What this PR does:
* properly fixes the following issues (which were not properly fixed in PR https://github.com/airflow-helm/charts/pull/102):
   - fixes #98
   - fixes #101
* fixes some bad wording on the `airflow.config.AIRFLOW__CORE__DAGS_FOLDER` value validation.
* addresses an issue with our `PYTHONPATH` when using `*.extraPipPackages`, which was overriding anything that the user set with `airflow.extraEnv`:
   - fixes #106
* fixes the `PYTHONPATH` not being set when using `airflow.kubernetesPodTemplate.extraPipPackages` with `pod_template.yaml`


## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [X] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
