### PR TITLE
extract probe path from AIRFLOW__WEBSERVER__BASE_URL + ingress path validation 

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.0.4
+version: 8.0.5
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -73,6 +73,14 @@
     {{- if .Values.ingress.web.path | hasSuffix "/" }}
     {{ required "The `ingress.web.path` should NOT include a trailing '/'!" nil }}
     {{- end }}
+    {{- if .Values.airflow.config.AIRFLOW__WEBSERVER__BASE_URL }}
+      {{- $webUrl := .Values.airflow.config.AIRFLOW__WEBSERVER__BASE_URL | urlParse }}
+      {{- if not (eq .Values.ingress.web.path (get $webUrl "path")) }}
+      {{ required (printf "The `ingress.web.path` must be compatable with `airflow.config.AIRFLOW__WEBSERVER__BASE_URL`! (try setting AIRFLOW__WEBSERVER__BASE_URL to 'http://{HOSTNAME}%s', rather than '%s')" .Values.ingress.web.path .Values.airflow.config.AIRFLOW__WEBSERVER__BASE_URL) nil }}
+      {{- end }}
+    {{- else }}
+      {{ required (printf "If `ingress.web.path` is set, then `airflow.config.AIRFLOW__WEBSERVER__BASE_URL` must be set! (try setting AIRFLOW__WEBSERVER__BASE_URL to 'http://{HOSTNAME}%s')" .Values.ingress.web.path) nil }}
+    {{- end }}
   {{- end }}
 
   {{/* Checks for `ingress.flower.path` */}}
@@ -85,8 +93,10 @@
     {{- end }}
     {{- if .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX }}
       {{- if not (eq .Values.ingress.flower.path .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX) }}
-      {{ required "The `ingress.flower.path` should be the same as `airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX`!" nil }}
+      {{ required (printf "The `ingress.flower.path` must be compatable with `airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX`! (try setting AIRFLOW__CELERY__FLOWER_URL_PREFIX to '%s', rather than '%s')" .Values.ingress.flower.path .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX) nil }}
       {{- end }}
+    {{- else }}
+      {{ required (printf "If `ingress.flower.path` is set, then `airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX` must be set! (try setting AIRFLOW__CELERY__FLOWER_URL_PREFIX to '%s')" .Values.ingress.flower.path) nil }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/airflow/templates/config/secret-config.yaml
+++ b/charts/airflow/templates/config/secret-config.yaml
@@ -95,11 +95,6 @@ stringData:
   AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL: {{ .Values.dags.gitSync.syncWait | quote }}
   {{- end }}
 
-  {{- if and (.Values.ingress.enabled) (.Values.ingress.flower.path) (not .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX) }}
-  ## ensuring the ingress path is aligned with flower URL prefix
-  AIRFLOW__CELERY__FLOWER_URL_PREFIX: {{ .Values.ingress.flower.path | quote }}
-  {{- end }}
-
   {{- if .Values.airflow.legacyCommands }}
   {{- if not .Values.airflow.config.AIRFLOW__WEBSERVER__RBAC }}
   ## default to the RBAC UI when in legacy mode

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -111,7 +111,8 @@ spec:
             failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
             httpGet:
               scheme: {{ include "airflow.web.scheme" . }}
-              path: "/health"
+              {{- $airflowUrl := .Values.airflow.config.AIRFLOW__WEBSERVER__BASE_URL | default "" | printf "%s/health" | urlParse }}
+              path: {{ get $airflowUrl "path" }}
               port: web
           {{- end }}
           {{- if .Values.web.readinessProbe.enabled }}
@@ -122,7 +123,8 @@ spec:
             failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
             httpGet:
               scheme: {{ include "airflow.web.scheme" . }}
-              path: "/health"
+              {{- $airflowUrl := .Values.airflow.config.AIRFLOW__WEBSERVER__BASE_URL | default "" | printf "%s/health" | urlParse }}
+              path: {{ get $airflowUrl "path" }}
               port: web
           {{- end }}
           {{- $extraVolumeMounts := .Values.web.extraVolumeMounts }}


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md -->

**What issues does your PR fix?**

- fixes #112 

**What does your PR do?**

Extracts the liveness and readiness path for the web container from the configured airflow base path. 
Configures /health by default if no base path is configured


## Checklist
<!-- Place an '[x]' completed tasks -->
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [x] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
