### PR TITLE
feat: Allow adding annotations to jobs. Useful for when wanting to in…

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.0.6
+version: 8.0.7
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/templates/jobs/job-create-connections.yaml
+++ b/charts/airflow/templates/jobs/job-create-connections.yaml
@@ -23,6 +23,10 @@ spec:
         chart: {{ include "airflow.labels.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+      annotations:
+        {{- if .Values.airflow.jobPodAnnotations }}
+        {{- toYaml .Values.airflow.jobPodAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       restartPolicy: OnFailure
       {{- if .Values.airflow.image.pullSecret }}

--- a/charts/airflow/templates/jobs/job-create-pools.yaml
+++ b/charts/airflow/templates/jobs/job-create-pools.yaml
@@ -23,6 +23,10 @@ spec:
         chart: {{ include "airflow.labels.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+      annotations:
+        {{- if .Values.airflow.jobPodAnnotations }}
+        {{- toYaml .Values.airflow.jobPodAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       restartPolicy: OnFailure
       {{- if .Values.airflow.image.pullSecret }}

--- a/charts/airflow/templates/jobs/job-create-users.yaml
+++ b/charts/airflow/templates/jobs/job-create-users.yaml
@@ -23,6 +23,10 @@ spec:
         chart: {{ include "airflow.labels.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+      annotations:
+        {{- if .Values.airflow.jobPodAnnotations }}
+        {{- toYaml .Values.airflow.jobPodAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       restartPolicy: OnFailure
       {{- if .Values.airflow.image.pullSecret }}

--- a/charts/airflow/templates/jobs/job-create-variables.yaml
+++ b/charts/airflow/templates/jobs/job-create-variables.yaml
@@ -23,6 +23,10 @@ spec:
         chart: {{ include "airflow.labels.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+      annotations:
+        {{- if .Values.airflow.jobPodAnnotations }}
+        {{- toYaml .Values.airflow.jobPodAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       restartPolicy: OnFailure
       {{- if .Values.airflow.image.pullSecret }}

--- a/charts/airflow/templates/jobs/job-upgrade-db.yaml
+++ b/charts/airflow/templates/jobs/job-upgrade-db.yaml
@@ -25,6 +25,10 @@ spec:
         app: {{ include "airflow.labels.app" . }}
         component: jobs
         release: {{ .Release.Name }}
+      annotations:
+        {{- if .Values.airflow.jobPodAnnotations }}
+        {{- toYaml .Values.airflow.jobPodAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       restartPolicy: OnFailure
       {{- if .Values.airflow.image.pullSecret }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -167,6 +167,11 @@ airflow:
   ##
   podAnnotations: {}
 
+  ## extra annotations for the job Pods
+  ##
+  ## - Useful if you want to disable istio sidecar injection. ie: sidecar.istio.io/inject: "false"
+  jobPodAnnotations: {}
+
   ## extra pip packages to install in the web/scheduler/worker/flower Pods
   ##
   ## EXAMPLE:


### PR DESCRIPTION
…ject istio annotations

Signed-off-by: Thet <10606114+thetko85@users.noreply.github.com>

<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md -->

**What does your PR do?**

Adds in configurable annotations for job related pods. This is in relation to scenarios where istio sidecar injection is enabled by default. This is problematic as explained here: https://medium.com/redbox-techblog/handling-istio-sidecars-in-kubernetes-jobs-c392661c4af7

## Checklist
<!-- Place an '[x]' completed tasks -->
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [ ] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
