### PR TITLE
strip wildcard from ingress path before comparing to configured webse…

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.0.6
+version: 8.0.7
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -75,7 +75,7 @@
     {{- end }}
     {{- if .Values.airflow.config.AIRFLOW__WEBSERVER__BASE_URL }}
       {{- $webUrl := .Values.airflow.config.AIRFLOW__WEBSERVER__BASE_URL | urlParse }}
-      {{- if not (eq .Values.ingress.web.path (get $webUrl "path")) }}
+      {{- if not (eq (.Values.ingress.web.path | trimSuffix "*" | trimSuffix "/") (get $webUrl "path")) }}
       {{ required (printf "The `ingress.web.path` must be compatable with `airflow.config.AIRFLOW__WEBSERVER__BASE_URL`! (try setting AIRFLOW__WEBSERVER__BASE_URL to 'http://{HOSTNAME}%s', rather than '%s')" .Values.ingress.web.path .Values.airflow.config.AIRFLOW__WEBSERVER__BASE_URL) nil }}
       {{- end }}
     {{- else }}
@@ -92,7 +92,7 @@
     {{ required "The `ingress.flower.path` should NOT include a trailing '/'!" nil }}
     {{- end }}
     {{- if .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX }}
-      {{- if not (eq .Values.ingress.flower.path .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX) }}
+      {{- if not (eq (.Values.ingress.flower.path | trimSuffix "*" | trimSuffix "/") .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX) }}
       {{ required (printf "The `ingress.flower.path` must be compatable with `airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX`! (try setting AIRFLOW__CELERY__FLOWER_URL_PREFIX to '%s', rather than '%s')" .Values.ingress.flower.path .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX) nil }}
       {{- end }}
     {{- else }}


### PR DESCRIPTION
…rver confing in validation script

Signed-off-by: bensta <9579702+bensta@users.noreply.github.com>

<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md -->


**What issues does your PR fix?**

- fixes #144 

**What does your PR do?**

The PR strips trailing wildcard and / characters from ingress config before comparing it to the AIRFLOW__WEBSERVER__BASE_URL (or the corresponding Flower path)

## Checklist
<!-- Place an '[x]' completed tasks -->
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [ ] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
