### PR TITLE
Allow parens in password

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.0.6
+version: 8.0.7
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/templates/config/secret-config.yaml
+++ b/charts/airflow/templates/config/secret-config.yaml
@@ -32,7 +32,7 @@ stringData:
 
   ## bash command which echos the URL encoded value of $DATABASE_PASSWORD
   DATABASE_PASSWORD_CMD: |-
-    echo ${DATABASE_PASSWORD} | python3 -c "import urllib.parse; encoded_pass = urllib.parse.quote(input()); print(encoded_pass)"
+    echo "${DATABASE_PASSWORD}" | python3 -c "import urllib.parse; encoded_pass = urllib.parse.quote(input()); print(encoded_pass)"
 
   ## bash command which echos the DB connection string in SQLAlchemy format
   DATABASE_SQLALCHEMY_CMD: |-


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md -->


**What issues does your PR fix?**
    Was getting the following exception in the worker logs for KubernetesExecutor when I had a password like password(withparens
    
```
    [2021-04-12 14:17:25,604] {logging_mixin.py:104} INFO - Running <TaskInstance: gitsynctutorial.print_date 2021-04-12T14:11:53.057909+00:00 [running]> on host gitsynctutorialprintdate.3bbeb001fcf4453d8596711a6e828149
    [2021-04-12 14:17:25,731] {taskinstance.py:1455} ERROR - Cannot execute bash -c 'eval "echo -n "postgresql+psycopg2://airflow:$(eval echo password(withparens | python3 -c "import urllib.parse; encoded_pass = urllib.parse.quote(input()); print(encoded_pass)")@host:5432/airflow""'. Error code is: 1. Output: , Stderr: bash: command substitution: line 1: syntax error near unexpected token `('
```

**What does your PR do?**

Puts the variable of the echo command in quotes so that the bash parsing does not fail


## Checklist
<!-- Place an '[x]' completed tasks -->
- [x ] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [ x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [ x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [ ] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [ ] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
