### PR TITLE
release 8.0.7

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.0.6
+version: 8.0.7
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -213,7 +213,7 @@ This method stores your DAGs inside the container image.
 > ⚠️ this chart uses the official [apache/airflow](https://hub.docker.com/r/apache/airflow) images, consult airflow's official [docs about custom images](https://airflow.apache.org/docs/apache-airflow/2.0.1/production-deployment.html#production-container-images)
 
 For example, extending `airflow:2.0.1-python3.8` with some dags:
-```docker
+```dockerfile
 FROM apache/airflow:2.0.1-python3.8
 
 # NOTE: dag path is set with the `dags.path` value
@@ -269,7 +269,7 @@ You can extend the airflow container image with your pip packages.
 > ⚠️ this chart uses the official [apache/airflow](https://hub.docker.com/r/apache/airflow) images, consult airflow's official [docs about custom images](https://airflow.apache.org/docs/apache-airflow/2.0.1/production-deployment.html#production-container-images)
 
 For example, extending `airflow:2.0.1-python3.8` with the `torch` package:
-```docker
+```dockerfile
 FROM apache/airflow:2.0.1-python3.8
 
 # install your pip packages
@@ -773,6 +773,9 @@ redis:
 
 Example values for an external Postgres database, with an existing `airflow_cluster1` database:
 ```yaml
+postgresql:
+  enabled: false
+
 externalDatabase:
   type: postgres
   host: postgres.example.org
@@ -789,6 +792,9 @@ externalDatabase:
 
 Example values for an external MySQL database, with an existing `airflow_cluster1` database:
 ```yaml
+postgresql:
+  enabled: false
+
 externalDatabase:
   type: mysql
   host: mysql.example.org

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -483,7 +483,7 @@ You can use the `airflow.connections` value to create airflow [Connections](http
 
 For example, to create connections called `my_aws`, `my_gcp`, `my_postgres`, and `my_ssh`:
 ```yaml
-scheduler:
+airflow:
   connections:
     ## see docs: https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html
     - id: my_aws

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -80,6 +80,37 @@ A __production__ starting point for GKE on Google Cloud (CeleryExecutor) | [link
 
 ## Airflow Configs
 
+### How to use a specific version of airflow?
+<details>
+<summary>Show More</summary>
+<hr>
+
+There will always be a single default version of airflow shipped with this chart, see `airflow.image.*` in [values.yaml](values.yaml) for the current one.
+
+However, given the general nature of the chart, it is likely that other versions of airflow will work too.
+
+For example, using airflow `2.0.1`, with python `3.6`:
+```yaml
+airflow:
+  image:
+    repository: apache/airflow
+    tag: 2.0.1-python3.6
+```
+
+For example, using airflow `1.10.15`, with python `3.8`:
+```yaml
+airflow:
+  # this must be "true" for airflow 1.10
+  legacyCommands: true
+  
+  image:
+    repository: apache/airflow
+    tag: 1.10.15-python3.8
+```
+
+<hr>
+</details>
+
 ### How to set airflow configs?
 <details>
 <summary>Show More</summary>

--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -42,8 +42,7 @@ spec:
       image: dummy_image
       imagePullPolicy: IfNotPresent
       envFrom:
-        - secretRef:
-            name: "{{ include "airflow.fullname" . }}-config"
+        {{- include "airflow.envFrom" . | indent 8 }}
       env:
         {{- if $extraPipPackages }}
         - name: PYTHONPATH

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -10,6 +10,20 @@
   {{- end }}
 {{- end }}
 
+{{/* Checks for `airflow.image` */}}
+{{- if eq .Values.airflow.image.repository "apache/airflow" }}
+  {{- if hasPrefix "1." .Values.airflow.image.tag }}
+    {{- if not .Values.airflow.legacyCommands }}
+    {{ required "When using airflow 1.10.X, `airflow.legacyCommands` must be `true`!" nil }}
+    {{- end }}
+  {{ end }}
+  {{- if hasPrefix "2." .Values.airflow.image.tag }}
+    {{- if .Values.airflow.legacyCommands }}
+    {{ required "When using airflow 2.X.X, `airflow.legacyCommands` must be `false`!" nil }}
+    {{- end }}
+  {{ end }}
+{{- end }}
+
 {{/* Checks for `airflow.executor` */}}
 {{- if not (has .Values.airflow.executor (list "CeleryExecutor" "CeleryKubernetesExecutor" "KubernetesExecutor")) }}
   {{ required "The `airflow.executor` must be one of: [CeleryExecutor, CeleryKubernetesExecutor, KubernetesExecutor]!" nil }}

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -75,11 +75,11 @@
     {{- end }}
     {{- if .Values.airflow.config.AIRFLOW__WEBSERVER__BASE_URL }}
       {{- $webUrl := .Values.airflow.config.AIRFLOW__WEBSERVER__BASE_URL | urlParse }}
-      {{- if not (eq .Values.ingress.web.path (get $webUrl "path")) }}
-      {{ required (printf "The `ingress.web.path` must be compatable with `airflow.config.AIRFLOW__WEBSERVER__BASE_URL`! (try setting AIRFLOW__WEBSERVER__BASE_URL to 'http://{HOSTNAME}%s', rather than '%s')" .Values.ingress.web.path .Values.airflow.config.AIRFLOW__WEBSERVER__BASE_URL) nil }}
+      {{- if not (eq (.Values.ingress.web.path | trimSuffix "/*") (get $webUrl "path")) }}
+      {{ required (printf "The `ingress.web.path` must be compatable with `airflow.config.AIRFLOW__WEBSERVER__BASE_URL`! (try setting AIRFLOW__WEBSERVER__BASE_URL to 'http://{HOSTNAME}%s', rather than '%s')" (.Values.ingress.web.path | trimSuffix "/*") .Values.airflow.config.AIRFLOW__WEBSERVER__BASE_URL) nil }}
       {{- end }}
     {{- else }}
-      {{ required (printf "If `ingress.web.path` is set, then `airflow.config.AIRFLOW__WEBSERVER__BASE_URL` must be set! (try setting AIRFLOW__WEBSERVER__BASE_URL to 'http://{HOSTNAME}%s')" .Values.ingress.web.path) nil }}
+      {{ required (printf "If `ingress.web.path` is set, then `airflow.config.AIRFLOW__WEBSERVER__BASE_URL` must be set! (try setting AIRFLOW__WEBSERVER__BASE_URL to 'http://{HOSTNAME}%s')" (.Values.ingress.web.path | trimSuffix "/*")) nil }}
     {{- end }}
   {{- end }}
 
@@ -92,11 +92,11 @@
     {{ required "The `ingress.flower.path` should NOT include a trailing '/'!" nil }}
     {{- end }}
     {{- if .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX }}
-      {{- if not (eq .Values.ingress.flower.path .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX) }}
-      {{ required (printf "The `ingress.flower.path` must be compatable with `airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX`! (try setting AIRFLOW__CELERY__FLOWER_URL_PREFIX to '%s', rather than '%s')" .Values.ingress.flower.path .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX) nil }}
+      {{- if not (eq (.Values.ingress.flower.path | trimSuffix "/*") .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX) }}
+      {{ required (printf "The `ingress.flower.path` must be compatable with `airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX`! (try setting AIRFLOW__CELERY__FLOWER_URL_PREFIX to '%s', rather than '%s')" (.Values.ingress.flower.path | trimSuffix "/*") .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX) nil }}
       {{- end }}
     {{- else }}
-      {{ required (printf "If `ingress.flower.path` is set, then `airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX` must be set! (try setting AIRFLOW__CELERY__FLOWER_URL_PREFIX to '%s')" .Values.ingress.flower.path) nil }}
+      {{ required (printf "If `ingress.flower.path` is set, then `airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX` must be set! (try setting AIRFLOW__CELERY__FLOWER_URL_PREFIX to '%s')" (.Values.ingress.flower.path | trimSuffix "/*")) nil }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -100,3 +100,23 @@
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{/* Checks for `externalDatabase` */}}
+{{- if .Values.externalDatabase.host }}
+  {{/* default value for `externalDatabase.host` is "localhost" */}}
+  {{- if not (eq .Values.externalDatabase.host "localhost") }}
+    {{- if .Values.postgresql.enabled }}
+    {{ required "If `externalDatabase.host` is set, then `postgresql.enabled` should be `false`!" nil }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{/* Checks for `externalRedis` */}}
+{{- if .Values.externalRedis.host }}
+  {{/* default value for `externalRedis.host` is "localhost" */}}
+  {{- if not (eq .Values.externalRedis.host "localhost") }}
+    {{- if .Values.redis.enabled }}
+    {{ required "If `externalRedis.host` is set, then `redis.enabled` should be `false`!" nil }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -32,10 +32,10 @@
 
 {{/* Checks for `airflow.config` */}}
 {{- if .Values.airflow.config.AIRFLOW__CORE__EXECUTOR }}
-  {{ required "Don't define `airflow.config.AIRFLOW__CORE__EXECUTOR`, it will be automatically set by the chart!" nil }}
+  {{ required "Don't define `airflow.config.AIRFLOW__CORE__EXECUTOR`, it will be automatically set from `airflow.executor`!" nil }}
 {{- end }}
 {{- if or .Values.airflow.config.AIRFLOW__CORE__DAGS_FOLDER }}
-  {{ required "Don't define `airflow.config.AIRFLOW__CORE__DAGS_FOLDER`, it will be automatically set by the chart!" nil }}
+  {{ required "Don't define `airflow.config.AIRFLOW__CORE__DAGS_FOLDER`, it will be automatically set from `dags.path`!" nil }}
 {{- end }}
 {{- if or (.Values.airflow.config.AIRFLOW__CELERY__BROKER_URL) (.Values.airflow.config.AIRFLOW__CELERY__BROKER_URL_CMD) }}
   {{ required "Don't define `airflow.config.AIRFLOW__CELERY__BROKER_URL`, it will be automatically set by the chart!" nil }}

--- a/charts/airflow/templates/config/secret-config.yaml
+++ b/charts/airflow/templates/config/secret-config.yaml
@@ -32,7 +32,7 @@ stringData:
 
   ## bash command which echos the URL encoded value of $DATABASE_PASSWORD
   DATABASE_PASSWORD_CMD: |-
-    echo ${DATABASE_PASSWORD} | python3 -c "import urllib.parse; encoded_pass = urllib.parse.quote(input()); print(encoded_pass)"
+    echo "${DATABASE_PASSWORD}" | python3 -c "import urllib.parse; encoded_pass = urllib.parse.quote(input()); print(encoded_pass)"
 
   ## bash command which echos the DB connection string in SQLAlchemy format
   DATABASE_SQLALCHEMY_CMD: |-
@@ -72,7 +72,7 @@ stringData:
   ## a bash command which echos the URL encoded value of $REDIS_PASSWORD
   ## NOTE: if $REDIS_PASSWORD is non-empty, prints `:${REDIS_PASSWORD}@`, else ``
   REDIS_PASSWORD_CMD: |-
-    echo ${REDIS_PASSWORD} | python3 -c "import urllib.parse; encoded_pass = urllib.parse.quote(input()); print(f\":{encoded_pass}@\") if len(encoded_pass) > 0 else None"
+    echo "${REDIS_PASSWORD}" | python3 -c "import urllib.parse; encoded_pass = urllib.parse.quote(input()); print(f\":{encoded_pass}@\") if len(encoded_pass) > 0 else None"
 
   ## a bash command which echos the Redis connection string
   REDIS_CONNECTION_CMD: |-

--- a/charts/airflow/templates/flower/flower-ingress.yaml
+++ b/charts/airflow/templates/flower/flower-ingress.yaml
@@ -21,7 +21,9 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingress.flower.host }}
+      {{- if .Values.ingress.flower.tls.secretName }}
       secretName: {{ .Values.ingress.flower.tls.secretName }}
+      {{- end }}
   {{- end }}
   rules:
     - http:

--- a/charts/airflow/templates/jobs/job-create-connections.yaml
+++ b/charts/airflow/templates/jobs/job-create-connections.yaml
@@ -17,6 +17,10 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
+      annotations:
+        {{- if .Values.airflow.podAnnotations }}
+        {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ include "airflow.labels.app" . }}
         component: jobs

--- a/charts/airflow/templates/jobs/job-create-pools.yaml
+++ b/charts/airflow/templates/jobs/job-create-pools.yaml
@@ -17,6 +17,10 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
+      annotations:
+        {{- if .Values.airflow.podAnnotations }}
+        {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ include "airflow.labels.app" . }}
         component: jobs

--- a/charts/airflow/templates/jobs/job-create-users.yaml
+++ b/charts/airflow/templates/jobs/job-create-users.yaml
@@ -17,6 +17,10 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
+      annotations:
+        {{- if .Values.airflow.podAnnotations }}
+        {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ include "airflow.labels.app" . }}
         component: jobs

--- a/charts/airflow/templates/jobs/job-create-variables.yaml
+++ b/charts/airflow/templates/jobs/job-create-variables.yaml
@@ -17,6 +17,10 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
+      annotations:
+        {{- if .Values.airflow.podAnnotations }}
+        {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ include "airflow.labels.app" . }}
         component: jobs

--- a/charts/airflow/templates/jobs/job-upgrade-db.yaml
+++ b/charts/airflow/templates/jobs/job-upgrade-db.yaml
@@ -21,6 +21,10 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
+      annotations:
+        {{- if .Values.airflow.podAnnotations }}
+        {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ include "airflow.labels.app" . }}
         component: jobs

--- a/charts/airflow/templates/jobs/job-upgrade-db.yaml
+++ b/charts/airflow/templates/jobs/job-upgrade-db.yaml
@@ -28,7 +28,9 @@ spec:
       labels:
         app: {{ include "airflow.labels.app" . }}
         component: jobs
+        chart: {{ include "airflow.labels.chart" . }}
         release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
     spec:
       restartPolicy: OnFailure
       {{- if .Values.airflow.image.pullSecret }}

--- a/charts/airflow/templates/jobs/secret-job-scripts.yaml
+++ b/charts/airflow/templates/jobs/secret-job-scripts.yaml
@@ -56,7 +56,8 @@ stringData:
         schema={{ .schema | quote }},
       {{- end }}
       {{- if .port }}
-        {{- if not (typeIs "float64" .port) }}
+        {{- if not (or (typeIs "float64" .port) (typeIs "int64" .port)) }}
+        {{- /* the type of a number could be float64 or int64 depending on how it was set */ -}}
         {{ required "each `port` in `airflow.connections` must be int-type!" nil }}
         {{- end }}
         port={{ .port }},
@@ -118,7 +119,8 @@ stringData:
       {{- range .Values.airflow.pools }}
       create_pool(
         name={{ (required "each `name` in `airflow.pools` must be non-empty!" .name) | quote }},
-        {{- if not (typeIs "float64" .slots) }}
+        {{- if not (or (typeIs "float64" .slots) (typeIs "int64" .slots)) }}
+        {{- /* the type of a number could be float64 or int64 depending on how it was set */ -}}
         {{ required "each `slots` in `airflow.pools` must be int-type!" nil }}
         {{- end }}
         slots={{ (required "each `slots` in `airflow.pools` must be non-empty!" .slots) }},

--- a/charts/airflow/templates/jobs/secret-job-scripts.yaml
+++ b/charts/airflow/templates/jobs/secret-job-scripts.yaml
@@ -241,7 +241,7 @@ stringData:
       variable.val = val
       return variable
 
-    {{- if .Values.airflow.poolsUpdate }}
+    {{- if .Values.airflow.variablesUpdate }}
     {{ "" }}
     def compare_variables(v1: Variable, v2: Variable) -> bool:
       return v1.key == v2.key \

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -33,7 +33,9 @@ spec:
     metadata:
       annotations:
         checksum/secret-config: {{ include (print $.Template.BasePath "/config/secret-config.yaml") . | sha256sum }}
+        {{- if include "airflow.executor.kubernetes_like" . }}
         checksum/config-pod-template: {{ include (print $.Template.BasePath "/config/configmap-pod-template.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/webserver/webserver-ingress.yaml
+++ b/charts/airflow/templates/webserver/webserver-ingress.yaml
@@ -21,7 +21,9 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingress.web.host }}
+      {{- if .Values.ingress.web.tls.secretName }}
       secretName: {{ .Values.ingress.web.tls.secretName }}
+      {{- end }}
   {{- end }}
   rules:
     - http:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1117,9 +1117,6 @@ ingress:
 
       ## the name of a pre-created Secret containing a TLS private key and certificate
       ##
-      ## NOTE:
-      ## - this MUST be specified if `tls.enabled` is true
-      ##
       secretName: ""
 
     ## http paths to add to the web Ingress before the default path
@@ -1175,9 +1172,6 @@ ingress:
       enabled: false
 
       ## the name of a pre-created Secret containing a TLS private key and certificate
-      ##
-      ## NOTE:
-      ## - this MUST be specified if `tls.enabled` is true
       ##
       secretName: ""
 


### PR DESCRIPTION
A patch release with lots of fixes:
* fix dockerfile code blocks in README
* only include checksum/config-pod-template for kubernetes_like executors
* give more information in value validation errors 
* prevent embedded postgres/redis being enabled at same time as external 
* use _helper variable in pod_template envFrom 
* include airflow.podAnnotations in jobs
   * partially closes https://github.com/airflow-helm/charts/pull/140
* add int64 to validation, so int variables set in bash work 
   * closes https://github.com/airflow-helm/charts/issues/136
* add missing pod labels to upgrade-db job 
* fix validation for wildcard ingress paths 
   * closes https://github.com/airflow-helm/charts/issues/144
* fix typo in connections example 
   * closes https://github.com/airflow-helm/charts/pull/148
* fix incorrect variable usage for variablesUpdate 
   * closes https://github.com/airflow-helm/charts/issues/139
*  add validation for airflow version with `airflow.legacyCommands` state
* add docs for using non-default airflow versions
* make `ingress.web/flower.tls.secretName` optional 
   * closes https://github.com/airflow-helm/charts/issues/41
* fix support for passwords with bash special characters 
   * closes https://github.com/airflow-helm/charts/pull/147

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [X] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
