### PR TITLE
introduce serviceAccount.automountServiceAccountToken variable

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.0.7
+version: 8.1.0
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/UPGRADE.md
+++ b/charts/airflow/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrading Steps
 
+## `v8.0.X` → `v8.1.0`
+- added `serviceAccount.automountServiceAccountToken` to give users the option to not mount any service account tokens in the airflow pods if they are not needed
+
 ## `v7.15.X` → `v8.0.0`
 
 > 🛑️️ this is a MAJOR update, meaning there are BREAKING changes

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -68,6 +68,7 @@ spec:
       tolerations:
         {{- toYaml .Values.flower.tolerations | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       {{- if .Values.flower.securityContext }}
       securityContext:

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -74,6 +74,7 @@ spec:
       securityContext:
         {{- toYaml .Values.scheduler.securityContext | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -68,6 +68,7 @@ spec:
       tolerations:
         {{- toYaml .Values.web.tolerations | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       {{- if .Values.web.securityContext }}
       securityContext:

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -61,6 +61,7 @@ spec:
       {{- else }}
       terminationGracePeriodSeconds: {{ .Values.workers.terminationPeriod }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       {{- if .Values.workers.nodeSelector }}
       nodeSelector:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1233,6 +1233,13 @@ serviceAccount:
   ##
   name: ""
 
+  ## if the service account token (created by this chart, preexisting, or default namespace serviceaccount) is automatically mounted in the pods
+  ##
+  ## NOTE:
+  ## - Set this to false if your airflow instance does not need k8s API access and you don't want any access token to be mounted into the airflow/flower pods
+  ##
+  automountServiceAccountToken: true
+
   ## annotations for the ServiceAccount
   ##
   ## EXAMPLE: (to use WorkloadIdentity in Google Cloud)


### PR DESCRIPTION
Signed-off-by: bensta <9579702+bensta@users.noreply.github.com>

<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md -->
This PR introduces a new variable `serviceAccount.automountServiceAccountToken` to give the user the choice to not mount any service account token. 
This is good practice if the pod does not need any k8s API access, e.g. if the celery operator is used

**What issues does your PR fix?**


**What does your PR do?**

- introduce  `serviceAccount.automountServiceAccountToken`  in values.yaml
- add corresponding entries in the manifests of worker/scheduler/flower/web pods
- documentation

## Checklist
<!-- Place an '[x]' completed tasks -->
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [x] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
