### PR TITLE
dag serialisation, removing gitsync from webserver deployment

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.0.7
+version: 8.0.8
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/templates/config/secret-config.yaml
+++ b/charts/airflow/templates/config/secret-config.yaml
@@ -89,6 +89,7 @@ stringData:
     bash -c 'eval "$DATABASE_SQLALCHEMY_CMD"'
   AIRFLOW__WEBSERVER__WEB_SERVER_PORT: "8080"
   AIRFLOW__CELERY__FLOWER_PORT: "5555"
+  AIRFLOW__CORE__STORE_DAG_CODE: "true"
 
   {{- if and (.Values.dags.gitSync.enabled) (not .Values.airflow.config.AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL) }}
   ## refresh the dags folder at the same frequency as git-sync
@@ -96,6 +97,7 @@ stringData:
   {{- end }}
 
   {{- if .Values.airflow.legacyCommands }}
+  AIRFLOW__CORE__STORE_SERIALIZED_DAGS: "true"
   {{- if not .Values.airflow.config.AIRFLOW__WEBSERVER__RBAC }}
   ## default to the RBAC UI when in legacy mode
   AIRFLOW__WEBSERVER__RBAC: "true"

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -135,9 +135,6 @@ spec:
               mountPath: /opt/airflow/webserver_config.py
               subPath: webserver_config.py
               readOnly: true
-        {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" . | indent 8 }}
-        {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Closing https://github.com/airflow-helm/charts/issues/152

Since GitSync isn't required on the webserver deployment whatsoever in both version 2.0 of Airflow and Airflow >= 1.10.7, this pull request recommends to deploy with DAG serialisation always turned on since this is more performant in general.

See https://airflow.apache.org/docs/apache-airflow/stable/dag-serialization.html and https://airflow.apache.org/docs/apache-airflow/1.10.12/dag-serialization.html for both Airflow version references.

This was tested and it works, DAGs are parsing from the scheduler pod. GitSync isn't necessary. 