### PR TITLE
release 8.0.8

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.0.7
+version: 8.0.8
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -815,6 +815,9 @@ externalDatabase:
   user: airflow_cluster1
   passwordSecret: "airflow-cluster1-postgres-password"
   passwordSecretKey: "postgresql-password"
+
+  # use this for any extra connection-string settings, e.g. ?sslmode=disable
+  properties: ""
 ```
 
 <h3>Option 2 - MySQL</h3>
@@ -834,6 +837,9 @@ externalDatabase:
   user: airflow_cluster1
   passwordSecret: "airflow-cluster1-mysql-password"
   passwordSecretKey: "mysql-password"
+
+  # use this for any extra connection-string settings, e.g. ?useSSL=false
+  properties: ""
 ```
 
 <hr>

--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -35,7 +35,9 @@ spec:
     {{- if $extraPipPackages }}
     {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 4 }}
     {{- end }}
+    {{- if .Values.dags.gitSync.enabled }}
     {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 4 }}
+    {{- end }}
   {{- end }}
   containers:
     - name: base

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -84,7 +84,11 @@ Define a container which regularly syncs a git-repo
 EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") }}
 */}}
 {{- define "airflow.container.git_sync" }}
+{{- if .sync_one_time }}
+- name: dags-git-clone
+{{- else }}
 - name: dags-git-sync
+{{- end }}
   image: {{ .Values.dags.gitSync.image.repository }}:{{ .Values.dags.gitSync.image.tag }}
   imagePullPolicy: {{ .Values.dags.gitSync.image.pullPolicy }}
   securityContext:

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -26,9 +26,9 @@ Define an init-container which checks the DB status
     - "bash"
     - "-c"
     {{- if .Values.airflow.legacyCommands }}
-    - "exec airflow checkdb"
+    - "exec timeout 16s airflow checkdb"
     {{- else }}
-    - "exec airflow db check"
+    - "exec timeout 16s airflow db check"
     {{- end }}
 {{- end }}
 

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -81,6 +81,9 @@ spec:
         {{- end }}
         {{- include "airflow.init_container.check_db" . | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" . | indent 8 }}
+        {{- if .Values.dags.gitSync.enabled }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
         {{- if .Values.scheduler.extraInitContainers }}
         {{- toYaml .Values.scheduler.extraInitContainers | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -79,7 +79,8 @@ spec:
         {{- end }}
         {{- include "airflow.init_container.check_db" . | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" . | indent 8 }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if and (.Values.dags.gitSync.enabled) (.Values.airflow.legacyCommands) }}
+        {{- /* after 2.0, webserver no longer needs the DAG files, due to DAG Serialization */ -}}
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
       containers:
@@ -138,7 +139,8 @@ spec:
               mountPath: /opt/airflow/webserver_config.py
               subPath: webserver_config.py
               readOnly: true
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if and (.Values.dags.gitSync.enabled) (.Values.airflow.legacyCommands) }}
+        {{- /* after 2.0, webserver no longer needs the DAG files, due to DAG Serialization */ -}}
         {{- include "airflow.container.git_sync" . | indent 8 }}
         {{- end }}
         {{- if .Values.airflow.extraContainers }}

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -79,6 +79,9 @@ spec:
         {{- end }}
         {{- include "airflow.init_container.check_db" . | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" . | indent 8 }}
+        {{- if .Values.dags.gitSync.enabled }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
       containers:
         - name: airflow-web
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -84,6 +84,9 @@ spec:
         {{- end }}
         {{- include "airflow.init_container.check_db" . | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" . | indent 8 }}
+        {{- if .Values.dags.gitSync.enabled }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
       containers:
         - name: airflow-worker
           {{- include "airflow.image" . | indent 10 }}


### PR DESCRIPTION
This is a patch release which includes:
* dont include git-sync containers in webserver for airflow 2.0 
   * closes https://github.com/airflow-helm/charts/issues/152
* ensure dags git repo is cloned before containers start
   * closes https://github.com/airflow-helm/charts/issues/124
* introduce timeout for check-db init-container
   * closes https://github.com/airflow-helm/charts/issues/153 
* only include git-sync init-container in pod_template if enabled
   * closes https://github.com/airflow-helm/charts/issues/158
* add properties to externalDatabase docs 