### PR TITLE
Add kubernetesPodTemplate.resources value

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.0.8
+version: 8.1.0
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -56,6 +56,10 @@ spec:
       ports: []
       command: []
       args: []
+      {{- if .Values.airflow.kubernetesPodTemplate.resources }}
+      resources:
+        {{- toYaml .Values.airflow.kubernetesPodTemplate.resources | nindent 8 }}
+      {{- end }}
       {{- $extraVolumeMounts := .Values.airflow.kubernetesPodTemplate.extraVolumeMounts }}
       {{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
       {{- if $volumeMounts }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -289,6 +289,13 @@ airflow:
     ##
     extraVolumes: []
 
+    ## resources requirements for the Pod template default "base" container
+    ##
+    ## SPEC - Resources:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    ##
+    resources: {}
+
 ###################################
 # Airflow - Scheduler Configs
 ###################################


### PR DESCRIPTION
Signed-off-by: Mathieu Thoretton <mathieu.thoretton@tiko.energy>

**What does your PR do?**

Add kubernetesPodTemplate.resources value in order to set default resources in the pod template. Because of default resources were missing it was causing some issues in our k8s dev cluster. 
I guess it won't hurt to add the possibility to add resources if needed. I tested it, it worked as expected.

## Checklist
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [x] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [ ] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
