### PR TITLE
Fix invalid yaml when airflow.podAnnotations is empty

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.0.8
+version: 8.0.9
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/templates/jobs/job-create-connections.yaml
+++ b/charts/airflow/templates/jobs/job-create-connections.yaml
@@ -17,10 +17,10 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
+      {{- if .Values.airflow.podAnnotations }}
       annotations:
-        {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
-        {{- end }}
+      {{- end }}
       labels:
         app: {{ include "airflow.labels.app" . }}
         component: jobs

--- a/charts/airflow/templates/jobs/job-create-pools.yaml
+++ b/charts/airflow/templates/jobs/job-create-pools.yaml
@@ -17,10 +17,10 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
+      {{- if .Values.airflow.podAnnotations }}
       annotations:
-        {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
-        {{- end }}
+      {{- end }}
       labels:
         app: {{ include "airflow.labels.app" . }}
         component: jobs

--- a/charts/airflow/templates/jobs/job-create-users.yaml
+++ b/charts/airflow/templates/jobs/job-create-users.yaml
@@ -17,10 +17,10 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
+      {{- if .Values.airflow.podAnnotations }}
       annotations:
-        {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
-        {{- end }}
+      {{- end }}
       labels:
         app: {{ include "airflow.labels.app" . }}
         component: jobs

--- a/charts/airflow/templates/jobs/job-create-variables.yaml
+++ b/charts/airflow/templates/jobs/job-create-variables.yaml
@@ -17,10 +17,10 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
+      {{- if .Values.airflow.podAnnotations }}
       annotations:
-        {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
-        {{- end }}
+      {{- end }}
       labels:
         app: {{ include "airflow.labels.app" . }}
         component: jobs

--- a/charts/airflow/templates/jobs/job-upgrade-db.yaml
+++ b/charts/airflow/templates/jobs/job-upgrade-db.yaml
@@ -21,10 +21,10 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
+      {{- if .Values.airflow.podAnnotations }}
       annotations:
-        {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
-        {{- end }}
+      {{- end }}
       labels:
         app: {{ include "airflow.labels.app" . }}
         component: jobs


### PR DESCRIPTION
When airflow.podAnnotations is empty the `annotations:` key is provided
with no values. This is tripping up kustomize with the error

```
error: <nil> is expected to be map[string]interface {}
```

## Checklist
<!-- Place an '[x]' completed tasks -->
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [x] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)


