### PR TITLE
Add value airflow.initContainer.resources to specify initContainer resources

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.0.8
+version: 8.0.9
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -30,6 +30,8 @@ Define an init-container which checks the DB status
     {{- else }}
     - "exec timeout 16s airflow db check"
     {{- end }}
+  resources:
+    {{- toYaml .Values.airflow.initContainers.resources | nindent 4 }}
 {{- end }}
 
 {{/*
@@ -54,6 +56,8 @@ Define an init-container which waits for DB migrations
     {{- else }}
     - "exec airflow db check-migrations -t 60"
     {{- end }}
+  resources:
+    {{- toYaml .Values.airflow.initContainers.resources | nindent 4 }}
 {{- end }}
 
 {{/*
@@ -74,6 +78,8 @@ EXAMPLE USAGE: {{ include "airflow.init_container.install_pip_packages" (dict "R
     {{- range .extraPipPackages }}
     - {{ . | quote }}
     {{- end }}
+  resources:
+    {{- toYaml .Values.airflow.initContainers.resources | nindent 4 }}
   volumeMounts:
     - name: python-site-packages
       mountPath: /opt/python/site-packages

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -203,6 +203,15 @@ airflow:
   ##
   extraVolumes: []
 
+  ## resources config for initContainers
+  ##
+  ## This applies for:
+  ## - check_db
+  ## - wait_for_db_migrations
+  ## - install_pip_packages
+  initContainers:
+    resources: {}
+
   ## configs to generate the AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE
   ##
   ## NOTE:


### PR DESCRIPTION
**What issues does your PR fix?**

- no issue opened yet

**What does your PR do?**

It adds the possibility to set ressources for the initContainers:
- check_db
- wait_for_db_migrations
- install_pip_packages


## Checklist
<!-- Place an '[x]' completed tasks -->
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [x] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [x] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
