### PR TITLE
release 8.1.1

### DIFF
--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: airflow is a platform to programmatically author, schedule, and monitor workflows
 name: airflow
-version: 8.1.0
+version: 8.1.1
 appVersion: 2.0.1
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -63,6 +63,7 @@ __NOTE:__
 
 Old Version | New Version | Upgrade Guide
 --- | --- | ---
+v8.0.X | v8.1.0 | [link](UPGRADE.md#v80x--v810)
 v7.15.X | v8.0.0 | [link](UPGRADE.md#v715x--v800)
 v7.14.X | v7.15.0 | [link](UPGRADE.md#v714x--v7150)
 v7.13.X | v7.14.0 | [link](UPGRADE.md#v713x--v7140)

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -624,6 +624,10 @@ For a worker pod you can calculate it: `WORKER_CONCURRENCY * 200Mi`, so for `10 
 In the following config if a worker consumes `80%` of `2Gi` (which will happen if it runs 9-10 tasks at the same time), an autoscaling event will be triggered, and a new worker will be added.
 If you have many tasks in a queue, Kubernetes will keep adding workers until maxReplicas reached, in this case `16`.
 ```yaml
+airflow:
+  config:
+    AIRFLOW__CELERY__WORKER_CONCURRENCY: 10
+
 workers:
   # the initial/minimum number of workers
   replicas: 2
@@ -649,8 +653,6 @@ workers:
           averageUtilization: 80
 
   celery:
-    instances: 10
-
     ## wait at most 9min for running tasks to complete before SIGTERM
     ## WARNING: 
     ## - some cloud cluster-autoscaler configs will not respect graceful termination 

--- a/charts/airflow/UPGRADE.md
+++ b/charts/airflow/UPGRADE.md
@@ -1,5 +1,10 @@
 # Upgrading Steps
 
+## `v8.0.X` → `v8.1.0`
+
+### VALUES - New:
+- `airflow.kubernetesPodTemplate.resources`
+
 ## `v7.15.X` → `v8.0.0`
 
 > 🛑️️ this is a MAJOR update, meaning there are BREAKING changes

--- a/charts/airflow/examples/google-gke/custom-values.yaml
+++ b/charts/airflow/examples/google-gke/custom-values.yaml
@@ -228,13 +228,6 @@ workers:
   ## configs for the celery worker Pods
   ##
   celery:
-    ## the number of tasks each celery worker can run at a time
-    ##
-    ## NOTE:
-    ## - sets AIRFLOW__CELERY__WORKER_CONCURRENCY
-    ##
-    instances: 10
-
     ## if we should wait for tasks to finish before SIGTERM of the celery worker
     ##
     gracefullTermination: true


### PR DESCRIPTION
__Changes:__
* Fixes the lack of `UPGRADE.md` docs for the `8.1.0` version created by https://github.com/airflow-helm/charts/pull/175
* Removes references to `workers.celery.instances` (which was removed in `8.0.0`)

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#squash-commits) (if appropriate)
- [X] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#versioning)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/CONTRIBUTING.md#linting)
