### PR TITLE
upgrade github workflows

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,12 +14,12 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.5.3
+          version: v3.6.1
 
       - name: Install chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.1.0
         with:
-          version: v3.3.1
+          version: v3.4.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,13 +22,14 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.5.3
+          version: v3.6.1
 
       - name: Add dependency chart repos
         run: |
           helm repo add stable https://charts.helm.sh/stable
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.0
+        uses: helm/chart-releaser-action@v1.2.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: "true"


### PR DESCRIPTION
Changes:
- Upgrades the versions of `helm`, `chart-testing`, `chart-releaser`
- Enables new `--skip-existing` feature of `chart-releaser` (https://github.com/helm/chart-releaser/pull/111)