### PR TITLE
fix: add `release` to worker Service selector

### DIFF
--- a/charts/airflow/templates/worker/worker-service.yaml
+++ b/charts/airflow/templates/worker/worker-service.yaml
@@ -19,4 +19,5 @@ spec:
   selector:
     app: {{ include "airflow.labels.app" . }}
     component: worker
+    release: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
**What does your PR do?**

- Adds `{{ .Release.Name }}` to worker Service `spec.selector`, ensuring no conflicts if two airflow installs exist in the same namespace.

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [ ] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
