### PR TITLE
fix: only validate `ingress.{web, flower}.path` if `ingress.enabled=true`

### DIFF
--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -92,7 +92,7 @@
 {{- end }}
 
 {{/* Checks for `ingress` */}}
-{{- if .Values.ingress }}
+{{- if .Values.ingress.enabled }}
   {{/* Checks for `ingress.web.path` */}}
   {{- if .Values.ingress.web.path }}
     {{- if not (.Values.ingress.web.path | hasPrefix "/") }}


### PR DESCRIPTION
**What issues does your PR fix?**

- resolves https://github.com/airflow-helm/charts/issues/247

**What does your PR do?**

- Implements changes described in:
   - https://github.com/airflow-helm/charts/issues/247

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
