### PR TITLE
fix: multiple Schedulers could run if `legacyCommands=true` due to `rollingUpdate`

### DIFF
--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -25,9 +25,15 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      ## multiple scheduler pods can safely run concurrently (in airflow 2.0+)
+      {{- if .Values.airflow.legacyCommands }}
+      ## only one scheduler can run concurrently (Airflow 1.10)
+      maxSurge: 0
+      maxUnavailable: 100%
+      {{- else }}
+      ## multiple schedulers can run concurrently (Airflow 2.0)
       maxSurge: 25%
       maxUnavailable: 0
+      {{- end }}
   selector:
     matchLabels:
       app: {{ include "airflow.labels.app" . }}


### PR DESCRIPTION
**What issues does your PR fix?**

- fixes https://github.com/airflow-helm/charts/issues/240

**What does your PR do?**

- Implements changes described in: https://github.com/airflow-helm/charts/issues/240

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
