### PR TITLE
fix: deploy git-sync in webserver, regardless of `airflow.legacyCommands`

### DIFF
--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -83,8 +83,7 @@ spec:
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- if and (.Values.dags.gitSync.enabled) (.Values.airflow.legacyCommands) }}
-        {{- /* after 2.0, webserver no longer needs the DAG files, due to DAG Serialization */ -}}
+        {{- if .Values.dags.gitSync.enabled }}
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
       containers:
@@ -137,8 +136,7 @@ spec:
               mountPath: /opt/airflow/webserver_config.py
               subPath: webserver_config.py
               readOnly: true
-        {{- if and (.Values.dags.gitSync.enabled) (.Values.airflow.legacyCommands) }}
-        {{- /* after 2.0, webserver no longer needs the DAG files, due to DAG Serialization */ -}}
+        {{- if .Values.dags.gitSync.enabled }}
         {{- include "airflow.container.git_sync" . | indent 8 }}
         {{- end }}
         {{- if .Values.airflow.extraContainers }}


### PR DESCRIPTION
**What issues does your PR fix?**

- resolves https://github.com/airflow-helm/charts/issues/251
- fixes https://github.com/airflow-helm/charts/issues/222#issuecomment-865765314
- removes the need for:
   - https://github.com/airflow-helm/charts/issues/160

**What does your PR do?**

- Implements changes described in:
   - https://github.com/airflow-helm/charts/issues/251 


## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
