### PR TITLE
chore: Clarifies the provenience and state of the chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
-# Airflow Community Helm Charts
+# Airflow User Community Helm Charts
+
+This chart is a user-community Helm Chart. Its "Powered by Apache Airflow" as stated by the
+[Apache Trademark Rules](https://www.apache.org/foundation/marks/faq/#poweredby) but it is
+not managed by the Apache Software Foundation.
+
+If you want to raise issues about this chart, please raise them in this project, not
+in the Apache Airflow one.
+
+Historically, it was one of the most used Airflow Chart (formerly named "stable chart") before the
+Apache Airflow project released their chart. You are free to continue to use the chart
+as it is continuosly updated and maintained by the user community, however we are
+working together with the Apache Airflow Community to help users to migrate to
+the [Official Apache Airflow Communty chart](https://airflow.apache.org/docs/helm-chart/stable/index.html).
 
 ## Charts
 
 | name | description |
 | --- | --- |
-| [charts/airflow](https://github.com/airflow-helm/charts/tree/main/charts/airflow) | the community Apache Airflow Helm Chart - used to deploy Apache Airflow on Kubernetes
+| [charts/airflow](https://github.com/airflow-helm/charts/tree/main/charts/airflow) | the user community Airflow Helm Chart - used to deploy Airflow on Kubernetes
 
 ## Repo Usage
 


### PR DESCRIPTION
We have many users confusing the Official Apache Airlfow Community
chart with the User Community one, due to ambiguous "Community"
name used. We agreed to make the distinction of "User Community"
vs. "Official Apache Airflow Community" charts.

This PR fixes the ambiguity and also documents the current state
of both charts, so that the users are not confused about it.