### PR TITLE
feat: add validation that `AIRFLOW__WEBSERVER__SECRET_KEY` is set when web is replicated

### DIFF
--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -61,6 +61,21 @@
   {{ required "Don't define `airflow.config.AIRFLOW__CORE__SQL_ALCHEMY_CONN`, it will be automatically set by the chart!" nil }}
 {{- end }}
 
+{{/* Checks for `web` */}}
+{{- if gt .Values.web.replicas 1. }}
+  {{- if not .Values.airflow.config.AIRFLOW__WEBSERVER__SECRET_KEY }}
+    {{- $foundKey := false }}
+    {{- range $env := .Values.airflow.extraEnv }}
+      {{- if eq $env.name "AIRFLOW__WEBSERVER__SECRET_KEY" }}
+        {{- $foundKey = true }}
+      {{- end }}
+    {{- end }}
+    {{- if not $foundKey }}
+      {{ required "If `web.replicas > 1`, you must define `AIRFLOW__WEBSERVER__SECRET_KEY`!" nil }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 {{/* Checks for `logs.persistence` */}}
 {{- if .Values.logs.persistence.enabled }}
   {{- if not (eq .Values.logs.persistence.accessMode "ReadWriteMany") }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -554,6 +554,10 @@ web:
 
   ## the number of web Pods to run
   ##
+  ## WARNING:
+  ##  - if set greater than `1`, you MUST set `AIRFLOW__WEBSERVER__SECRET_KEY`,
+  ##    this prevents "CSRF session token is missing" errors when users are served by multiple web pods
+  ##
   ## NOTE:
   ## - if you set this >1 we recommend defining a `web.podDisruptionBudget`
   ##


### PR DESCRIPTION
**What issues does your PR fix?**

- fixes #265 

**What does your PR do?**

- Adds validation that `AIRFLOW__WEBSERVER__SECRET_KEY` is set when `web.replicas` is greater than `1`.


## Checklist
<!-- Place an '[x]' completed tasks -->
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [x] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
