### PR TITLE
feat: implement pgbouncer support

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1033,6 +1033,10 @@ serviceAccount:
 > 
 > The embedded Postgres is NOT SUITABLE for production, you should follow [How to use an external database?](#how-to-use-an-external-database)
 
+> 🟨 __Note__ 🟨
+>
+> If `pgbouncer.enabled=true` (the default), we will deploy [PgBouncer](https://www.pgbouncer.org/) to pool connections to your external database 
+
 The embedded Postgres database has an insecure username/password by default, you should create secure credentials before using it.
 
 For example, to create the required Kubernetes Secrets:
@@ -1068,6 +1072,10 @@ redis:
 <hr>
 
 <h3>Option 1 - Postgres</h3>
+
+> 🟨 __Note__ 🟨
+>
+> If `pgbouncer.enabled=true` (the default), we will deploy [PgBouncer](https://www.pgbouncer.org/) to pool connections to your external database
 
 Example values for an external Postgres database, with an existing `airflow_cluster1` database:
 ```yaml
@@ -1643,6 +1651,38 @@ Parameter | Description | Default
 Parameter | Description | Default
 --- | --- | ---
 `extraManifests` | extra Kubernetes manifests to include alongside this chart | `[]`
+
+<hr>
+</details>
+
+### `pgbouncer.*`
+<details>
+<summary>Expand</summary>
+<hr>
+
+Parameter | Description | Default
+--- | --- | ---
+`pgbouncer.enabled` | if the pgbouncer Deployment is created | `true`
+`pgbouncer.image.*` | configs for the pgbouncer container image | `<see values.yaml>`
+`pgbouncer.resources` | resource requests/limits for the pgbouncer Pods | `{}`
+`pgbouncer.nodeSelector` | the nodeSelector configs for the pgbouncer Pods | `{}`
+`pgbouncer.affinity` | the affinity configs for the pgbouncer Pods | `{}`
+`pgbouncer.tolerations` | the toleration configs for the pgbouncer Pods | `[]`
+`pgbouncer.securityContext` | the security context for the pgbouncer Pods | `{}`
+`pgbouncer.labels` | labels for the pgbouncer Deployment | `{}`
+`pgbouncer.podLabels` | Pod labels for the pgbouncer Deployment | `{}`
+`pgbouncer.annotations` | annotations for the pgbouncer Deployment | `{}`
+`pgbouncer.podAnnotations` | Pod annotations for the pgbouncer Deployment | `{}`
+`pgbouncer.safeToEvict` | if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true" | `true`
+`pgbouncer.podDisruptionBudget.*` | configs for the PodDisruptionBudget of the pgbouncer | `<see values.yaml>`
+`pgbouncer.livenessProbe.*` | configs for the pgbouncer Pods' liveness probe | `<see values.yaml>`
+`pgbouncer.terminationGracePeriodSeconds` | the maximum number of seconds to wait for queries upon pod termination, before force killing | `120`
+`pgbouncer.maxClientConnections` | sets pgbouncer config: `max_client_conn` | `100`
+`pgbouncer.poolSize` | sets pgbouncer config: `default_pool_size` | `20`
+`pgbouncer.logDisconnections` | sets pgbouncer config: `log_disconnections` | `0`
+`pgbouncer.logConnections` | sets pgbouncer config: `log_connections` | `0`
+`pgbouncer.clientSSL.*` | ssl configs for: clients -> pgbouncer | `<see values.yaml>`
+`pgbouncer.serverSSL.*` | ssl configs for: pgbouncer -> postgres | `<see values.yaml>`
 
 <hr>
 </details>

--- a/charts/airflow/templates/_helpers/common.tpl
+++ b/charts/airflow/templates/_helpers/common.tpl
@@ -72,6 +72,17 @@ The path containing DAG files
 {{- end -}}
 
 {{/*
+If PgBouncer should be used.
+*/}}
+{{- define "airflow.pgbouncer.should_use" -}}
+{{- if .Values.pgbouncer.enabled -}}
+{{- if or (.Values.postgresql.enabled) (eq .Values.externalDatabase.type "postgres") -}}
+true
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Construct the `postgresql.fullname` of the postgresql sub-chat chart.
 Used to discover the Service and Secret name created by the sub-chart.
 */}}

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -134,6 +134,30 @@
   {{- end }}
 {{- end }}
 
+{{/* Checks for `pgbouncer` */}}
+{{- if include "airflow.pgbouncer.should_use" . }}
+    {{- if .Values.pgbouncer.clientSSL.keyFile.existingSecret }}
+        {{- if not .Values.pgbouncer.clientSSL.certFile.existingSecret }}
+        {{ required "If `pgbouncer.clientSSL.keyFile.existingSecret` is set, then `pgbouncer.clientSSL.certFile.existingSecret` must also be!" nil }}
+        {{- end }}
+    {{- end }}
+    {{- if .Values.pgbouncer.clientSSL.certFile.existingSecret }}
+        {{- if not .Values.pgbouncer.clientSSL.keyFile.existingSecret }}
+        {{ required "If `pgbouncer.clientSSL.certFile.existingSecret` is set, then `pgbouncer.clientSSL.keyFile.existingSecret` must also be!" nil }}
+        {{- end }}
+    {{- end }}
+    {{- if .Values.pgbouncer.serverSSL.keyFile.existingSecret }}
+        {{- if not .Values.pgbouncer.serverSSL.certFile.existingSecret }}
+        {{ required "If `pgbouncer.serverSSL.keyFile.existingSecret` is set, then `pgbouncer.serverSSL.certFile.existingSecret` must also be!" nil }}
+        {{- end }}
+    {{- end }}
+    {{- if .Values.pgbouncer.serverSSL.certFile.existingSecret }}
+        {{- if not .Values.pgbouncer.serverSSL.keyFile.existingSecret }}
+        {{ required "If `pgbouncer.serverSSL.certFile.existingSecret` is set, then `pgbouncer.serverSSL.keyFile.existingSecret` must also be!" nil }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
 {{/* Checks for `externalDatabase` */}}
 {{- if .Values.externalDatabase.host }}
   {{/* check if they are using externalDatabase (the default value for `externalDatabase.host` is "localhost") */}}

--- a/charts/airflow/templates/config/secret-config.yaml
+++ b/charts/airflow/templates/config/secret-config.yaml
@@ -16,16 +16,24 @@ stringData:
   ## ================
   ## Database Configs
   ## ================
-  ## connection string components
-  {{- if .Values.postgresql.enabled }}
-  DATABASE_HOST: {{ (include "airflow.postgresql.fullname" .) | quote }}
+  ## database host/port
+  {{- if include "airflow.pgbouncer.should_use" . }}
+  DATABASE_HOST: {{ printf "%s-pgbouncer.%s.svc.cluster.local" (include "airflow.fullname" .) (.Release.Namespace) | quote }}
+  DATABASE_PORT: "6432"
+  {{- else if .Values.postgresql.enabled }}
+  DATABASE_HOST: {{ printf "%s.%s.svc.cluster.local" (include "airflow.postgresql.fullname" .) (.Release.Namespace) | quote }}
   DATABASE_PORT: "5432"
-  DATABASE_USER: {{ .Values.postgresql.postgresqlUsername | quote }}
-  DATABASE_DB: {{ .Values.postgresql.postgresqlDatabase | quote }}
   {{- else }}
   DATABASE_HOST: {{ .Values.externalDatabase.host | quote }}
   DATABASE_PORT: {{ .Values.externalDatabase.port | quote }}
-  DATABASE_USER: {{ .Values.externalDatabase.user | quote}}
+  {{- end }}
+
+  ## database configs
+  {{- if .Values.postgresql.enabled }}
+  DATABASE_USER: {{ .Values.postgresql.postgresqlUsername | quote }}
+  DATABASE_DB: {{ .Values.postgresql.postgresqlDatabase | quote }}
+  {{- else }}
+  DATABASE_USER: {{ .Values.externalDatabase.user | quote }}
   DATABASE_DB: {{ .Values.externalDatabase.database | quote }}
   DATABASE_PROPERTIES: {{ .Values.externalDatabase.properties | quote }}
   {{- end }}
@@ -54,13 +62,17 @@ stringData:
     echo -n "db+mysql://${DATABASE_USER}:$(eval $DATABASE_PASSWORD_CMD)@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DB}${DATABASE_PROPERTIES}"
     {{- end }}
 
+  ## bash command which echos the DB connection string in `psql` cli format
+  DATABASE_PSQL_CMD: |-
+    echo -n "postgresql://${DATABASE_USER}:$(eval $DATABASE_PASSWORD_CMD)@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DB}${DATABASE_PROPERTIES}"
+
   ## ================
   ## Redis Configs
   ## ================
   {{- if include "airflow.executor.celery_like" . }}
   ## connection string components
   {{- if .Values.redis.enabled }}
-  REDIS_HOST: "{{ include "airflow.redis.fullname" . }}-master"
+  REDIS_HOST: {{ printf "%s-master.%s.svc.cluster.local" (include "airflow.redis.fullname" .) (.Release.Namespace) | quote }}
   REDIS_PORT: "6379"
   REDIS_DBNUM: "1"
   {{- else }}

--- a/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
+++ b/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
@@ -1,0 +1,65 @@
+{{/*
+Define the content of the `pgbouncer.ini` config file.
+*/}}
+{{- define "airflow.pgbouncer.pgbouncer.ini" }}
+[databases]
+{{- if .Values.postgresql.enabled }}
+airflow = host={{ printf "%s.%s.svc.cluster.local" (include "airflow.postgresql.fullname" .) (.Release.Namespace) }} port=5432
+{{- else }}
+airflow = host={{ .Values.externalDatabase.host }} port={{ .Values.externalDatabase.port }}
+{{- end }}
+
+[pgbouncer]
+pool_mode = transaction
+max_client_conn = {{ .Values.pgbouncer.maxClientConnections }}
+default_pool_size =  {{ .Values.pgbouncer.poolSize }}
+ignore_startup_parameters = extra_float_digits
+
+listen_port = 6432
+listen_addr = *
+
+auth_type = md5
+auth_file = /home/pgbouncer/users.txt
+
+log_disconnections = {{ .Values.pgbouncer.logDisconnections }}
+log_connections = {{ .Values.pgbouncer.logConnections }}
+
+## CLIENT TLS SETTINGS ##
+client_tls_sslmode = {{ .Values.pgbouncer.clientSSL.mode }}
+client_tls_ciphers = {{ .Values.pgbouncer.clientSSL.ciphers }}
+client_tls_ca_file = /home/pgbouncer/certs/client-ca.crt
+client_tls_key_file = /home/pgbouncer/certs/client.key
+client_tls_cert_file = /home/pgbouncer/certs/client.crt
+
+## SERVER TLS SETTINGS ##
+server_tls_sslmode = {{ .Values.pgbouncer.serverSSL.mode }}
+server_tls_ciphers = {{ .Values.pgbouncer.serverSSL.ciphers }}
+server_tls_ca_file = /home/pgbouncer/certs/server-ca.crt
+server_tls_key_file = /home/pgbouncer/certs/server.key
+server_tls_cert_file = /home/pgbouncer/certs/server.crt
+
+{{- end }}
+
+{{/*
+Define the content of the `gen_auth_file.sh` sh script.
+*/}}
+{{- define "airflow.pgbouncer.gen_auth_file.sh" }}
+#!/bin/sh -e
+
+# DESCRIPTION:
+# - updates the pgbouncer `auth_file` from environment variables
+# - called in main pgbouncer container start-command so that `auth_file` is updated each restart,
+#   for example, when the livenessProbe fails due to a DATABASE_PASSWORD secret update
+
+# variables to increase clarity of pattern matching
+ONE_QUOTE='"'
+TWO_QUOTE='""'
+
+# pgbouncer requires `"` to be escaped as `""`
+ESCAPED_DATABASE_USER="${DATABASE_USER/$ONE_QUOTE/$TWO_QUOTE}"
+ESCAPED_DATABASE_PASSWORD="${DATABASE_PASSWORD/$ONE_QUOTE/$TWO_QUOTE}"
+
+# pgbouncer requires auth_file in format `"my-username" "my-password"`
+echo \"$ESCAPED_DATABASE_USER\" \"$ESCAPED_DATABASE_PASSWORD\" > /home/pgbouncer/users.txt
+echo "Successfully generated auth_file: /home/pgbouncer/users.txt"
+{{- end }}

--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -1,0 +1,233 @@
+{{- if include "airflow.pgbouncer.should_use" . }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.pgbouncer.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.pgbouncer.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.pgbouncer.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.pgbouncer.securityContext) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "airflow.fullname" . }}-pgbouncer
+  labels:
+    app: {{ include "airflow.labels.app" . }}
+    component: pgbouncer
+    chart: {{ include "airflow.labels.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- if .Values.pgbouncer.annotations }}
+  annotations:
+  {{- toYaml .Values.pgbouncer.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      ## multiple pgbouncer pods can safely run concurrently
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: {{ include "airflow.labels.app" . }}
+      component: pgbouncer
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/secret-config: {{ include (print $.Template.BasePath "/config/secret-config.yaml") . | sha256sum }}
+        checksum/secret-pgbouncer: {{ include (print $.Template.BasePath "/pgbouncer/pgbouncer-secret.yaml") . | sha256sum }}
+        {{- if .Values.airflow.podAnnotations }}
+        {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.pgbouncer.podAnnotations }}
+        {{- toYaml .Values.pgbouncer.podAnnotations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.pgbouncer.safeToEvict }}
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        {{- end }}
+      labels:
+        app: {{ include "airflow.labels.app" . }}
+        component: pgbouncer
+        release: {{ .Release.Name }}
+        {{- if .Values.pgbouncer.podLabels }}
+        {{- toYaml .Values.pgbouncer.podLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      restartPolicy: Always
+      {{- if .Values.airflow.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.airflow.image.pullSecret }}
+      {{- end }}
+      {{- if $podNodeSelector }}
+      nodeSelector:
+        {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podAffinity }}
+      affinity:
+        {{- $podAffinity | nindent 8 }}
+      {{- end }}
+      {{- if $podTolerations }}
+      tolerations:
+        {{- $podTolerations | nindent 8 }}
+      {{- end }}
+      {{- if $podSecurityContext }}
+      securityContext:
+        {{- $podSecurityContext | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.pgbouncer.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "airflow.serviceAccountName" . }}
+      containers:
+        - name: pgbouncer
+          image: {{ .Values.pgbouncer.image.repository }}:{{ .Values.pgbouncer.image.tag }}
+          imagePullPolicy: {{ .Values.pgbouncer.image.pullPolicy }}
+          securityContext:
+            runAsUser: {{ .Values.pgbouncer.image.uid }}
+            runAsGroup: {{ .Values.pgbouncer.image.gid }}
+          resources:
+            {{- toYaml .Values.pgbouncer.resources | nindent 12 }}
+          envFrom:
+            {{- include "airflow.envFrom" . | indent 12 }}
+          env:
+            {{- include "airflow.env" . | indent 12 }}
+          ports:
+            - name: pgbouncer
+              containerPort: 6432
+              protocol: TCP
+          command:
+            - "/usr/bin/dumb-init"
+            ## rewrite SIGTERM as SIGINT, so pgbouncer does a safe shutdown
+            - "--rewrite=15:2"
+            - "--"
+          args:
+            - "/bin/sh"
+            - "-c"
+            ## we generate users.txt on startup, because DATABASE_PASSWORD is defined from a Secret,
+            ## and we want to pickup the new values on container restart (possibly due to livenessProbe failure)
+            - |-
+              /home/pgbouncer/config/gen_auth_file.sh && \
+              exec pgbouncer /home/pgbouncer/config/pgbouncer.ini
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.pgbouncer.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.pgbouncer.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.pgbouncer.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.pgbouncer.livenessProbe.failureThreshold }}
+            exec:
+              command:
+                - "/bin/sh"
+                - "-c"
+                ## this check is intended to fail when the DATABASE_PASSWORD secret is updated,
+                ## which would cause `gen_auth_file.sh` to run again on container start
+                - psql $(eval $DATABASE_PSQL_CMD) --tuples-only --command="SELECT 1;" | grep -q "1"
+          readinessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+            tcpSocket:
+              port: 6432
+          volumeMounts:
+            - name: pgbouncer-config
+              mountPath: /home/pgbouncer/config
+              readOnly: true
+            - name: pgbouncer-certs
+              mountPath: /home/pgbouncer/certs
+              readOnly: true
+      volumes:
+        - name: pgbouncer-config
+          secret:
+            secretName: {{ include "airflow.fullname" . }}-pgbouncer
+            items:
+              - key: gen_auth_file.sh
+                path: gen_auth_file.sh
+                mode: 0755
+              - key: pgbouncer.ini
+                path: pgbouncer.ini
+        - name: pgbouncer-certs
+          projected:
+            sources:
+              {{- if or (not .Values.pgbouncer.clientSSL.caFile.existingSecret) (not .Values.pgbouncer.clientSSL.keyFile.existingSecret) (not .Values.pgbouncer.clientSSL.certFile.existingSecret) }}
+              ## CLIENT TLS FILES (AUTO GENERATED)
+              - secret:
+                  name: {{ include "airflow.fullname" . }}-pgbouncer-certs
+                  items:
+                    {{- if not .Values.pgbouncer.clientSSL.caFile.existingSecret }}
+                    - key: client-ca.crt
+                      path: client-ca.crt
+                    {{- end }}
+                    {{- if not .Values.pgbouncer.clientSSL.keyFile.existingSecret }}
+                    - key: client.key
+                      path: client.key
+                    {{- end }}
+                    {{- if not .Values.pgbouncer.clientSSL.certFile.existingSecret }}
+                    - key: client.crt
+                      path: client.crt
+                    {{- end }}
+              {{- end }}
+
+              {{- if or (not .Values.pgbouncer.serverSSL.caFile.existingSecret) (not .Values.pgbouncer.serverSSL.keyFile.existingSecret) (not .Values.pgbouncer.serverSSL.certFile.existingSecret) }}
+              ## SERVER TLS FILES (AUTO GENERATED)
+              - secret:
+                  name: {{ include "airflow.fullname" . }}-pgbouncer-certs
+                  items:
+                    {{- if not .Values.pgbouncer.serverSSL.caFile.existingSecret }}
+                    - key: server-ca.crt
+                      path: server-ca.crt
+                    {{- end }}
+                    {{- if not .Values.pgbouncer.serverSSL.keyFile.existingSecret }}
+                    - key: server.key
+                      path: server.key
+                    {{- end }}
+                    {{- if not .Values.pgbouncer.serverSSL.certFile.existingSecret }}
+                    - key: server.crt
+                      path: server.crt
+                    {{- end }}
+              {{- end }}
+
+              {{- if or (.Values.pgbouncer.clientSSL.caFile.existingSecret) (.Values.pgbouncer.clientSSL.keyFile.existingSecret) (.Values.pgbouncer.clientSSL.certFile.existingSecret) }}
+              ## CLIENT TLS FILES (USER CUSTOM)
+              {{- if .Values.pgbouncer.clientSSL.caFile.existingSecret }}
+              - secret:
+                  name: {{ .Values.pgbouncer.clientSSL.caFile.existingSecret }}
+                  items:
+                    - key: {{ .Values.pgbouncer.clientSSL.caFile.existingSecretKey }}
+                      path: client-ca.crt
+              {{- end }}
+              {{- if .Values.pgbouncer.clientSSL.keyFile.existingSecret }}
+              - secret:
+                  name: {{ .Values.pgbouncer.clientSSL.keyFile.existingSecret }}
+                  items:
+                    - key: {{ .Values.pgbouncer.clientSSL.keyFile.existingSecretKey }}
+                      path: client.key
+              {{- end }}
+              {{- if .Values.pgbouncer.clientSSL.certFile.existingSecret }}
+              - secret:
+                  name: {{ .Values.pgbouncer.clientSSL.certFile.existingSecret }}
+                  items:
+                    - key: {{ .Values.pgbouncer.clientSSL.certFile.existingSecretKey }}
+                      path: client.crt
+              {{- end }}
+              {{- end }}
+
+              {{- if or (.Values.pgbouncer.serverSSL.caFile.existingSecret) (.Values.pgbouncer.serverSSL.keyFile.existingSecret) (.Values.pgbouncer.serverSSL.certFile.existingSecret) }}
+              ## SERVER TLS FILES (USER CUSTOM)
+              {{- if .Values.pgbouncer.serverSSL.caFile.existingSecret }}
+              - secret:
+                  name: {{ .Values.pgbouncer.serverSSL.caFile.existingSecret }}
+                  items:
+                    - key: {{ .Values.pgbouncer.serverSSL.caFile.existingSecretKey }}
+                      path: server-ca.crt
+              {{- end }}
+              {{- if .Values.pgbouncer.serverSSL.keyFile.existingSecret }}
+              - secret:
+                  name: {{ .Values.pgbouncer.serverSSL.keyFile.existingSecret }}
+                  items:
+                    - key: {{ .Values.pgbouncer.serverSSL.keyFile.existingSecretKey }}
+                      path: server.key
+              {{- end }}
+              {{- if .Values.pgbouncer.serverSSL.certFile.existingSecret }}
+              - secret:
+                  name: {{ .Values.pgbouncer.serverSSL.certFile.existingSecret }}
+                  items:
+                    - key: {{ .Values.pgbouncer.serverSSL.certFile.existingSecretKey }}
+                      path: server.crt
+              {{- end }}
+              {{- end }}
+{{- end }}

--- a/charts/airflow/templates/pgbouncer/pgbouncer-pdb.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-pdb.yaml
@@ -1,0 +1,24 @@
+{{- if and (include "airflow.pgbouncer.should_use" .) (.Values.pgbouncer.podDisruptionBudget.enabled) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "airflow.fullname" . }}-pgbouncer
+  labels:
+    app: {{ include "airflow.labels.app" . }}
+    component: pgbouncer
+    chart: {{ include "airflow.labels.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  {{- if .Values.pgbouncer.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.pgbouncer.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- if .Values.pgbouncer.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.pgbouncer.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ include "airflow.labels.app" . }}
+      component: pgbouncer
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/airflow/templates/pgbouncer/pgbouncer-secret-certs.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-secret-certs.yaml
@@ -1,0 +1,38 @@
+{{- $any_client_needed :=  or (not .Values.pgbouncer.clientSSL.caFile.existingSecret) (not .Values.pgbouncer.clientSSL.keyFile.existingSecret) (not .Values.pgbouncer.clientSSL.certFile.existingSecret) }}
+{{- $any_server_needed :=  or (not .Values.pgbouncer.serverSSL.caFile.existingSecret) (not .Values.pgbouncer.serverSSL.keyFile.existingSecret) (not .Values.pgbouncer.serverSSL.certFile.existingSecret) }}
+{{- if and (include "airflow.pgbouncer.should_use" .) (or $any_client_needed $any_server_needed) }}
+{{- $client_ca := genCA "client-ca" 365 }}
+{{- $client_cert := genSignedCert "localhost" nil nil 365 $client_ca }}
+{{- $server_ca := genCA "server-ca" 365 }}
+{{- $server_cert := genSignedCert "localhost" nil nil 365 $server_ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "airflow.fullname" . }}-pgbouncer-certs
+  labels:
+    app: {{ include "airflow.labels.app" . }}
+    component: pgbouncer
+    chart: {{ include "airflow.labels.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- if not .Values.pgbouncer.clientSSL.caFile.existingSecret }}
+  client-ca.crt: {{ $client_ca.Cert | b64enc | quote }}
+  {{- end }}
+  {{- if not .Values.pgbouncer.clientSSL.keyFile.existingSecret }}
+  client.key: {{ $client_cert.Key | b64enc | quote }}
+  {{- end }}
+  {{- if not .Values.pgbouncer.clientSSL.certFile.existingSecret }}
+  client.crt: {{ $client_cert.Cert  | b64enc | quote }}
+  {{- end }}
+
+  {{- if not .Values.pgbouncer.serverSSL.caFile.existingSecret }}
+  server-ca.crt: {{ $server_ca.Cert | b64enc | quote }}
+  {{- end }}
+  {{- if not .Values.pgbouncer.serverSSL.keyFile.existingSecret }}
+  server.key: {{ $server_cert.Key | b64enc | quote }}
+  {{- end }}
+  {{- if not .Values.pgbouncer.serverSSL.certFile.existingSecret }}
+  server.crt: {{ $server_cert.Cert | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/airflow/templates/pgbouncer/pgbouncer-secret.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-secret.yaml
@@ -1,0 +1,15 @@
+{{- if include "airflow.pgbouncer.should_use" . }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "airflow.fullname" . }}-pgbouncer
+  labels:
+    app: {{ include "airflow.labels.app" . }}
+    component: pgbouncer
+    chart: {{ include "airflow.labels.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  pgbouncer.ini: {{ include "airflow.pgbouncer.pgbouncer.ini" . | b64enc | quote }}
+  gen_auth_file.sh: {{ include "airflow.pgbouncer.gen_auth_file.sh" . | b64enc | quote }}
+{{- end }}

--- a/charts/airflow/templates/pgbouncer/pgbouncer-service.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-service.yaml
@@ -1,0 +1,22 @@
+{{- if include "airflow.pgbouncer.should_use" . }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "airflow.fullname" . }}-pgbouncer
+  labels:
+    app: {{ include "airflow.labels.app" . }}
+    component: pgbouncer
+    chart: {{ include "airflow.labels.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ include "airflow.labels.app" . }}
+    component: pgbouncer
+    release: {{ .Release.Name }}
+  ports:
+    - name: pgbouncer
+      protocol: TCP
+      port: 6432
+{{- end }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1351,6 +1351,177 @@ serviceAccount:
 extraManifests: []
 
 ###################################
+## DATABASE | PgBouncer
+###################################
+pgbouncer:
+  ## if the pgbouncer Deployment is created
+  ##
+  enabled: true
+
+  ## configs for the pgbouncer container image
+  ##
+  image:
+    repository: ghcr.io/airflow-helm/pgbouncer
+    tag: 1.15.0-patch.0
+    pullPolicy: IfNotPresent
+    uid: 1001
+    gid: 1001
+
+  ## resource requests/limits for the pgbouncer Pods
+  ## - spec for ResourceRequirements:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+  ##
+  resources: {}
+
+  ## the nodeSelector configs for the pgbouncer Pods
+  ## - docs for nodeSelector:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  ##
+  nodeSelector: {}
+
+  ## the affinity configs for the pgbouncer Pods
+  ## - spec for Affinity:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+  ##
+  affinity: {}
+
+  ## the toleration configs for the pgbouncer Pods
+  ## - spec for Toleration:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+  ##
+  tolerations: []
+
+  ## the security context for the pgbouncer Pods
+  ## - spec for PodSecurityContext:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+  ##
+  securityContext: {}
+
+  ## labels for the pgbouncer Deployment
+  ##
+  labels: {}
+
+  ## Pod labels for the pgbouncer Deployment
+  ##
+  podLabels: {}
+
+  ## annotations for the pgbouncer Deployment
+  ##
+  annotations: {}
+
+  ## Pod annotations for the pgbouncer Deployment
+  ##
+  podAnnotations: {}
+
+  ## if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true"
+  ##
+  safeToEvict: true
+
+  ## configs for the PodDisruptionBudget of the pgbouncer Deployment
+  ##
+  podDisruptionBudget:
+    ## if a PodDisruptionBudget resource is created for the pgbouncer Deployment
+    ##
+    enabled: false
+
+    ## the maximum unavailable pods/percentage for the pgbouncer Deployment
+    ##
+    maxUnavailable:
+
+    ## the minimum available pods/percentage for the pgbouncer Deployment
+    ##
+    minAvailable:
+
+  ## configs for the pgbouncer Pods' liveness probe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 30
+    timeoutSeconds: 15
+    failureThreshold: 3
+
+  ## the maximum number of seconds to wait for queries upon pod termination, before force killing
+  ##
+  terminationGracePeriodSeconds: 120
+
+  ## sets pgbouncer config: `max_client_conn`
+  ##
+  maxClientConnections: 100
+
+  ## sets pgbouncer config: `default_pool_size`
+  ##
+  poolSize: 20
+
+  ## sets pgbouncer config: `log_disconnections`
+  ##
+  logDisconnections: 0
+
+  ## sets pgbouncer config: `log_connections`
+  ##
+  logConnections: 0
+
+  ## ssl configs for: clients -> pgbouncer
+  ## - if `caFile`, `keyFile`, `certFile` are not provided, we auto generate self-signed certificates
+  ##
+  clientSSL:
+    ## sets pgbouncer config: `client_tls_sslmode`
+    ##
+    mode: prefer
+
+    ## sets pgbouncer config: `client_tls_ciphers`
+    ##
+    ciphers: normal
+
+    ## sets pgbouncer config: `client_tls_ca_file`
+    ##
+    caFile:
+      existingSecret: ""
+      existingSecretKey: root.crt
+
+    ## sets pgbouncer config: `client_tls_key_file`
+    ##
+    keyFile:
+      existingSecret: ""
+      existingSecretKey: client.key
+
+    ## sets pgbouncer config: `client_tls_cert_file`
+    ##
+    certFile:
+      existingSecret: ""
+      existingSecretKey: client.crt
+
+  ## ssl configs for: pgbouncer -> postgres
+  ## - if `caFile`, `keyFile`, `certFile` are not provided, we auto generate self-signed certificates
+  ##
+  serverSSL:
+    ## sets pgbouncer config: `server_tls_sslmode`
+    ##
+    mode: prefer
+
+    ## sets pgbouncer config: `server_tls_ciphers`
+    ##
+    ciphers: normal
+
+    ## sets pgbouncer config: `server_tls_ca_file`
+    ##
+    caFile:
+      existingSecret: ""
+      existingSecretKey: root.crt
+
+    ## sets pgbouncer config: `server_tls_key_file`
+    ##
+    keyFile:
+      existingSecret: ""
+      existingSecretKey: server.key
+
+    ## sets pgbouncer config: `server_tls_cert_file`
+    ##
+    certFile:
+      existingSecret: ""
+      existingSecretKey: server.crt
+
+###################################
 ## DATABASE | Embedded Postgres
 ###################################
 postgresql:


### PR DESCRIPTION
**What issues does your PR fix?**

- resolves #235
- fixes #227


**What does your PR do?**

- Implements [PgBouncer](https://www.pgbouncer.org/) to pool connections and reduce the possibility of "too many connections" errors:
    - `pgbouncer.enabled` (default: `true`)
    - `pgbouncer.image`:
        - `pgbouncer.image.repository` (default: `ghcr.io/airflow-helm/pgbouncer`)
        - `pgbouncer.image.tag` (default =`1.15.0-patch.0`)
        - `pgbouncer.image.pullPolicy`(default: `IfNotPresent`)
        - `pgbouncer.image.uid` (default: `1001`)
        - `pgbouncer.image.gid` (default: `1001`)
    - `pgbouncer.resources`
    - `pgbouncer.nodeSelector`
    - `pgbouncer.affinity`
    - `pgbouncer.tolerations`
    - `pgbouncer.securityContext`
    - `pgbouncer.labels`
    - `pgbouncer.podLabels`
    - `pgbouncer.annotations`
    - `pgbouncer.podAnnotations`
    - `pgbouncer.safeToEvict`
    - `pgbouncer.podDisruptionBudget`:
        - `pgbouncer.podDisruptionBudget.enabled` (default: `false`)
        - `pgbouncer.podDisruptionBudget.maxUnavailable`
        - `pgbouncer.podDisruptionBudget.minAvailable`
    - `pgbouncer.livenessProbe`:
        - `pgbouncer.livenessProbe.enabled` (default: `true`)
        - `pgbouncer.livenessProbe.initialDelaySeconds` (default: `5`)
        - `pgbouncer.livenessProbe.periodSeconds` (default: `30`)
        - `pgbouncer.livenessProbe.timeoutSeconds` (default: `15`)
        - `pgbouncer.livenessProbe.failureThreshold` (default: `3`)
    - `pgbouncer.maxClientConnections` (default: `100`)
    - `pgbouncer.poolSize` (default: `20`)
    - `pgbouncer.logDisconnections` (default: `0`)
    - `pgbouncer.logConnections` (default: `0`)
    - `pgbouncer.terminationGracePeriodSeconds` (default: `120`)
    - `pgbouncer.clientSSL`:
        - `pgbouncer.clientSSL.mode` (default: `prefer`)
        - `pgbouncer.clientSSL.ciphers` (default: `normal`)
        - `pgbouncer.clientSSL.caFile.existingSecret`
        - `pgbouncer.clientSSL.caFile.existingSecretKey` (default: `root.crt`)
        - `pgbouncer.clientSSL.keyFile.existingSecret`
        - `pgbouncer.clientSSL.keyFile.existingSecretKey` (default: `client.key`)
        - `pgbouncer.clientSSL.certFile.existingSecret`
        - `pgbouncer.clientSSL.certFile.existingSecretKey` (default: `client.key`)
    - `pgbouncer.serverSSL`:
        - `pgbouncer.serverSSL.mode` (default: `prefer`)
        - `pgbouncer.serverSSL.ciphers` (default: `normal`)
        - `pgbouncer.serverSSL.caFile.existingSecret`
        - `pgbouncer.serverSSL.caFile.existingSecretKey` (default: `root.crt`)
        - `pgbouncer.serverSSL.keyFile.existingSecret`
        - `pgbouncer.serverSSL.keyFile.existingSecretKey` (default: `server.key`)
        - `pgbouncer.serverSSL.certFile.existingSecret`
        - `pgbouncer.serverSSL.certFile.existingSecretKey` (default: `server.key`)

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
