### PR TITLE
feat: add `airflow.webserverSecretKey` value

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -590,6 +590,43 @@ airflow:
 <hr>
 </details>
 
+### How to set a custom webserver secret_key?
+<details>
+<summary>Expand</summary>
+<hr>
+
+<h3>Option 1 - using the value</h3>
+
+> 🟥 __Warning__ 🟥
+>
+> We strongly recommend that you DO NOT USE the default `airflow.webserverSecretKey` in production.
+
+You can set the webserver secret_key using the `airflow.webserverSecretKey` value, which sets the `AIRFLOW__WEBSERVER__SECRET_KEY` environment variable.
+
+Example values to define the secret_key with `airflow.webserverSecretKey`:
+```yaml
+aiflow:
+  webserverSecretKey: "THIS IS UNSAFE!"
+```
+
+<h3>Option 2 - using a secret (recommended)</h3>
+
+You can set the webserver secret_key from a Kubernetes Secret by referencing it with the `airflow.extraEnv` value.
+
+Example values to use the `value` key from the existing Secret `airflow-webserver-secret-key`:
+```yaml
+airflow:
+  extraEnv:
+    - name: AIRFLOW__WEBSERVER__SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: airflow-webserver-secret-key
+          key: value
+```
+
+<hr>
+</details>
+
 ### How to create airflow connections?
 <details>
 <summary>Expand</summary>
@@ -1292,6 +1329,7 @@ Parameter | Description | Default
 `airflow.image.*` | configs for the airflow container image | `<see values.yaml>`
 `airflow.executor` | the airflow executor type to use | `CeleryExecutor`
 `airflow.fernetKey` | the fernet encryption key for connections/variables, sets `AIRFLOW__CORE__FERNET_KEY` | `7T512UXSSmBOkpWimFHIVb8jK6lfmSAvx4mO6Arehnc=`
+`airflow.webserverSecretKey` | the secret_key for flask, sets `AIRFLOW__WEBSERVER__SECRET_KEY` | `THIS IS UNSAFE!`
 `airflow.config` | environment variables for airflow configs | `{}`
 `airflow.users` | a list of users to create | `<see values.yaml>`
 `airflow.usersTemplates` | bash-like templates to be used in `airflow.users` | `<see values.yaml>`

--- a/charts/airflow/templates/config/secret-config.yaml
+++ b/charts/airflow/templates/config/secret-config.yaml
@@ -90,6 +90,7 @@ data:
   AIRFLOW__CORE__EXECUTOR: {{ .Values.airflow.executor | b64enc | quote }}
   AIRFLOW__CORE__FERNET_KEY: {{ .Values.airflow.fernetKey | b64enc | quote }}
   AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD: {{ `bash -c 'eval "$DATABASE_SQLALCHEMY_CMD"'` | b64enc | quote }}
+  AIRFLOW__WEBSERVER__SECRET_KEY: {{ .Values.airflow.webserverSecretKey | b64enc | quote }}
   AIRFLOW__WEBSERVER__WEB_SERVER_PORT: {{ "8080" | b64enc | quote }}
   AIRFLOW__CELERY__FLOWER_PORT: {{ "5555" | b64enc | quote }}
 

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -42,6 +42,14 @@ airflow:
   ##
   fernetKey: "7T512UXSSmBOkpWimFHIVb8jK6lfmSAvx4mO6Arehnc="
 
+  ## the secret_key for flask, sets `AIRFLOW__WEBSERVER__SECRET_KEY`
+  ##
+  ## WARNING:
+  ## - you MUST CHANGE THIS to ensure the security of your airflow
+  ## - use `airflow.extraEnv` with a Secret to avoid storing this value in plain-text
+  ##
+  webserverSecretKey: "THIS IS UNSAFE!"
+
   ## environment variables for airflow configs
   ##
   ## NOTE:


### PR DESCRIPTION
**What issues does your PR fix?**

- resolves: https://github.com/airflow-helm/charts/issues/332
- fixes: https://github.com/airflow-helm/charts/issues/327
- fixes: https://github.com/airflow-helm/charts/issues/72

**What does your PR do?**

- Implements the changes described in:
   - https://github.com/airflow-helm/charts/issues/332
- Adds the following values:
   - `airflow.webserverSecretKey` (default: `THIS IS UNSAFE!`)

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
