### PR TITLE
fix: scheduler livenessProbe exit codes

### DIFF
--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -125,6 +125,7 @@ spec:
                 - "-Wignore"
                 - "-c"
                 - |
+                  import sys
                   from typing import List
                   from airflow.jobs.scheduler_job import SchedulerJob
                   from airflow.utils.db import create_session
@@ -142,11 +143,12 @@ spec:
                       count_alive_jobs = len(alive_jobs)
 
                   if count_alive_jobs == 1:
-                      print(f"HEALTHY - {count_alive_jobs} alive SchedulerJob for: {hostname}")
+                      # scheduler is healthy - we expect one SchedulerJob per scheduler
+                      pass
                   elif count_alive_jobs == 0:
-                      SystemExit(f"UNHEALTHY - 0 alive SchedulerJob for: {hostname}")
+                      sys.exit(f"UNHEALTHY - 0 alive SchedulerJob for: {hostname}")
                   else:
-                      SystemExit(f"UNHEALTHY - {count_alive_jobs} (more than 1) alive SchedulerJob for: {hostname}")
+                      sys.exit(f"UNHEALTHY - {count_alive_jobs} (more than 1) alive SchedulerJob for: {hostname}")
           {{- end }}
           {{- if or ($volumeMounts) (include "airflow.executor.kubernetes_like" .) }}
           volumeMounts:


### PR DESCRIPTION
**What issues does your PR fix?**

- fixes #340

**What does your PR do?**

- Fixed airflow scheduler `livenessProbe` so it exits with code `1` on error

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
