### PR TITLE
fix: make pod_template use `airflow.image.*` values

### DIFF
--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -45,8 +45,7 @@ spec:
   {{- end }}
   containers:
     - name: base
-      image: dummy_image
-      imagePullPolicy: IfNotPresent
+      {{- include "airflow.image" . | indent 6 }}
       envFrom:
         {{- include "airflow.envFrom" . | indent 8 }}
       env:


### PR DESCRIPTION
**What issues does your PR fix?**

- fixes #349

**What does your PR do?**

- Make the KubernetesExecutor `pod_template.yaml` use the `airflow.image` _helper template, meaning these values are now respected:
   -  `airflow.image.repository` (also being set by `AIRFLOW__KUBERNETES__WORKER_CONTAINER_REPOSITORY`) 
   -  `airflow.image.tag` (also being set by `AIRFLOW__KUBERNETES__WORKER_CONTAINER_TAG`) 
   - `airflow.image.pullPolicy`
   - `airflow.image.uid`
   - `airflow.image.gid`

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
