### PR TITLE
feat: include `airflow.{config,extraEnv}` in pip-install container

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -341,6 +341,19 @@ worker:
     - "torch~=1.8.0"
 ```
 
+Example values to install pip packages from a private pip `--index-url`:
+```yaml
+airflow:
+  config:
+    ## pip configs can be set with environment variables
+    PIP_TIMEOUT: 60
+    PIP_INDEX_URL: https://<username>:<password>@example.com/packages/simple/
+    PIP_TRUSTED_HOST: example.com
+  
+  extraPipPackages:
+    - "my-internal-package==1.0.0"
+```
+
 <h3>Option 2 - embedded into container image (recommended)</h3>
 
 This chart uses the official [apache/airflow](https://hub.docker.com/r/apache/airflow) images, consult airflow's official [docs about custom images](https://airflow.apache.org/docs/apache-airflow/2.0.1/production-deployment.html#production-container-images), you can extend the airflow container image with your pip packages.

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -122,6 +122,10 @@ EXAMPLE USAGE: {{ include "airflow.init_container.install_pip_packages" (dict "R
 {{- define "airflow.init_container.install_pip_packages" }}
 - name: install-pip-packages
   {{- include "airflow.image" . | indent 2 }}
+  envFrom:
+    {{- include "airflow.envFrom" . | indent 4 }}
+  env:
+    {{- include "airflow.env" . | indent 4 }}
   command:
     - "/usr/bin/dumb-init"
     - "--"
@@ -129,6 +133,7 @@ EXAMPLE USAGE: {{ include "airflow.init_container.install_pip_packages" (dict "R
     - "bash"
     - "-c"
     - |
+      unset PYTHONUSERBASE && \
       pip install --user {{ range .extraPipPackages }}{{ . | quote }} {{ end }} && \
       echo "copying '/home/airflow/.local/*' to '/opt/home-airflow-local'..." && \
       cp -r /home/airflow/.local/* /opt/home-airflow-local


### PR DESCRIPTION
**What issues does your PR fix?**

- resolves https://github.com/airflow-helm/charts/issues/324
- fixes https://github.com/airflow-helm/charts/issues/115
- fixes https://github.com/airflow-helm/charts/issues/322

**What does your PR do?**

- Includes `airflow.config` and `airflow.extraEnv` in the pip-install init-container, as described in:
   - https://github.com/airflow-helm/charts/issues/324
- Adds docs for how to set `--index-url` with `extraPipPackages`

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
