### PR TITLE
fix: typos in sync/_helpers templates

### DIFF
--- a/charts/airflow/templates/sync/_helpers/global_code.tpl
+++ b/charts/airflow/templates/sync/_helpers/global_code.tpl
@@ -1,7 +1,7 @@
 {{/*
 Code which is included in all python sync scripts.
 */}}
-{{- define "airflow.snyc.global_code" }}
+{{- define "airflow.sync.global_code" }}
 ####################
 ## Global Imports ##
 ####################

--- a/charts/airflow/templates/sync/_helpers/snyc_connections.tpl
+++ b/charts/airflow/templates/sync/_helpers/snyc_connections.tpl
@@ -1,11 +1,11 @@
 {{/*
 The python sync script for connections.
 */}}
-{{- define "airflow.snyc.sync_connections.py" }}
+{{- define "airflow.sync.sync_connections.py" }}
 ############################
 #### BEGIN: GLOBAL CODE ####
 ############################
-{{- include "airflow.snyc.global_code" . }}
+{{- include "airflow.sync.global_code" . }}
 ##########################
 #### END: GLOBAL CODE ####
 ##########################

--- a/charts/airflow/templates/sync/_helpers/snyc_pools.tpl
+++ b/charts/airflow/templates/sync/_helpers/snyc_pools.tpl
@@ -1,11 +1,11 @@
 {{/*
 The python sync script for pools.
 */}}
-{{- define "airflow.snyc.sync_pools.py" }}
+{{- define "airflow.sync.sync_pools.py" }}
 ############################
 #### BEGIN: GLOBAL CODE ####
 ############################
-{{- include "airflow.snyc.global_code" . }}
+{{- include "airflow.sync.global_code" . }}
 ##########################
 #### END: GLOBAL CODE ####
 ##########################

--- a/charts/airflow/templates/sync/_helpers/snyc_variables.tpl
+++ b/charts/airflow/templates/sync/_helpers/snyc_variables.tpl
@@ -1,11 +1,11 @@
 {{/*
 The python sync script for variables.
 */}}
-{{- define "airflow.snyc.sync_variables.py" }}
+{{- define "airflow.sync.sync_variables.py" }}
 ############################
 #### BEGIN: GLOBAL CODE ####
 ############################
-{{- include "airflow.snyc.global_code" . }}
+{{- include "airflow.sync.global_code" . }}
 ##########################
 #### END: GLOBAL CODE ####
 ##########################

--- a/charts/airflow/templates/sync/_helpers/sync_users.tpl
+++ b/charts/airflow/templates/sync/_helpers/sync_users.tpl
@@ -1,11 +1,11 @@
 {{/*
 The python sync script for users.
 */}}
-{{- define "airflow.snyc.sync_users.py" }}
+{{- define "airflow.sync.sync_users.py" }}
 ############################
 #### BEGIN: GLOBAL CODE ####
 ############################
-{{- include "airflow.snyc.global_code" . }}
+{{- include "airflow.sync.global_code" . }}
 ##########################
 #### END: GLOBAL CODE ####
 ##########################

--- a/charts/airflow/templates/sync/sync-connections-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-connections-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         checksum/secret-config: {{ include (print $.Template.BasePath "/config/secret-config.yaml") . | sha256sum }}
-        checksum/sync-connections-script: {{ include "airflow.snyc.sync_connections.py" . | sha256sum }}
+        checksum/sync-connections-script: {{ include "airflow.sync.sync_connections.py" . | sha256sum }}
         {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/sync/sync-connections-job.yaml
+++ b/charts/airflow/templates/sync/sync-connections-job.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         checksum/secret-config: {{ include (print $.Template.BasePath "/config/secret-config.yaml") . | sha256sum }}
-        checksum/sync-connections-script: {{ include "airflow.snyc.sync_connections.py" . | sha256sum }}
+        checksum/sync-connections-script: {{ include "airflow.sync.sync_connections.py" . | sha256sum }}
         {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/sync/sync-connections-secret.yaml
+++ b/charts/airflow/templates/sync/sync-connections-secret.yaml
@@ -11,5 +11,5 @@ metadata:
     heritage: {{ .Release.Service }}
 stringData:
   sync_connections.py: |-
-    {{- include "airflow.snyc.sync_connections.py" . | indent 4 }}
+    {{- include "airflow.sync.sync_connections.py" . | indent 4 }}
 {{- end }}

--- a/charts/airflow/templates/sync/sync-pools-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-pools-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         checksum/secret-config: {{ include (print $.Template.BasePath "/config/secret-config.yaml") . | sha256sum }}
-        checksum/sync-pools-script: {{ include "airflow.snyc.sync_pools.py" . | sha256sum }}
+        checksum/sync-pools-script: {{ include "airflow.sync.sync_pools.py" . | sha256sum }}
         {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/sync/sync-pools-job.yaml
+++ b/charts/airflow/templates/sync/sync-pools-job.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         checksum/secret-config: {{ include (print $.Template.BasePath "/config/secret-config.yaml") . | sha256sum }}
-        checksum/sync-pools-script: {{ include "airflow.snyc.sync_pools.py" . | sha256sum }}
+        checksum/sync-pools-script: {{ include "airflow.sync.sync_pools.py" . | sha256sum }}
         {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/sync/sync-pools-secret.yaml
+++ b/charts/airflow/templates/sync/sync-pools-secret.yaml
@@ -11,5 +11,5 @@ metadata:
     heritage: {{ .Release.Service }}
 stringData:
   sync_pools.py: |-
-    {{- include "airflow.snyc.sync_pools.py" . | indent 4 }}
+    {{- include "airflow.sync.sync_pools.py" . | indent 4 }}
 {{- end }}

--- a/charts/airflow/templates/sync/sync-users-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-users-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         checksum/secret-config: {{ include (print $.Template.BasePath "/config/secret-config.yaml") . | sha256sum }}
-        checksum/sync-users-script: {{ include "airflow.snyc.sync_users.py" . | sha256sum }}
+        checksum/sync-users-script: {{ include "airflow.sync.sync_users.py" . | sha256sum }}
         {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/sync/sync-users-job.yaml
+++ b/charts/airflow/templates/sync/sync-users-job.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         checksum/secret-config: {{ include (print $.Template.BasePath "/config/secret-config.yaml") . | sha256sum }}
-        checksum/sync-users-script: {{ include "airflow.snyc.sync_users.py" . | sha256sum }}
+        checksum/sync-users-script: {{ include "airflow.sync.sync_users.py" . | sha256sum }}
         {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/sync/sync-users-secret.yaml
+++ b/charts/airflow/templates/sync/sync-users-secret.yaml
@@ -11,5 +11,5 @@ metadata:
     heritage: {{ .Release.Service }}
 stringData:
   sync_users.py: |-
-    {{- include "airflow.snyc.sync_users.py" . | indent 4 }}
+    {{- include "airflow.sync.sync_users.py" . | indent 4 }}
 {{- end }}

--- a/charts/airflow/templates/sync/sync-variables-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-variables-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         checksum/secret-config: {{ include (print $.Template.BasePath "/config/secret-config.yaml") . | sha256sum }}
-        checksum/sync-variables-script: {{ include "airflow.snyc.sync_variables.py" . | sha256sum }}
+        checksum/sync-variables-script: {{ include "airflow.sync.sync_variables.py" . | sha256sum }}
         {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/sync/sync-variables-job.yaml
+++ b/charts/airflow/templates/sync/sync-variables-job.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         checksum/secret-config: {{ include (print $.Template.BasePath "/config/secret-config.yaml") . | sha256sum }}
-        checksum/sync-variables-script: {{ include "airflow.snyc.sync_variables.py" . | sha256sum }}
+        checksum/sync-variables-script: {{ include "airflow.sync.sync_variables.py" . | sha256sum }}
         {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/sync/sync-variables-secret.yaml
+++ b/charts/airflow/templates/sync/sync-variables-secret.yaml
@@ -11,5 +11,5 @@ metadata:
     heritage: {{ .Release.Service }}
 stringData:
   sync_variables.py: |-
-    {{- include "airflow.snyc.sync_variables.py" . | indent 4 }}
+    {{- include "airflow.sync.sync_variables.py" . | indent 4 }}
 {{- end }}


### PR DESCRIPTION
**What issues does your PR fix?**

- resolves https://github.com/airflow-helm/charts/issues/364

**What does your PR do?**

- Replaces "snyc" -> "sync" in `sync/_helpers` templates

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
