### PR TITLE
refactor: remove broken `flower.oauthDomains` value

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1492,7 +1492,6 @@ Parameter | Description | Default
 `flower.podAnnotations` | Pod annotations for the flower Deployment | `{}`
 `flower.safeToEvict` | if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true" | `true`
 `flower.podDisruptionBudget.*` | configs for the PodDisruptionBudget of the flower Deployment | `<see values.yaml>`
-`flower.oauthDomains` | the value of the flower `--auth` argument | `""`
 `flower.basicAuthSecret` | the name of a pre-created secret containing the basic authentication value for flower | `""`
 `flower.basicAuthSecretKey` | the key within `flower.basicAuthSecret` containing the basic authentication string | `""`
 `flower.service.*` | configs for the Service of the flower Pods | `<see values.yaml>`

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -106,17 +106,13 @@ spec:
           command:
             - "/usr/bin/dumb-init"
             - "--"
+          args:
             - "bash"
             - "-c"
-          args:
             {{- if .Values.airflow.legacyCommands }}
             - "exec airflow flower"
             {{- else }}
             - "exec airflow celery flower"
-            {{- end }}
-            {{- if .Values.flower.oauthDomains }}
-            - "--auth"
-            - {{ .Values.flower.oauthDomains | quote }}
             {{- end }}
           {{- if .Values.flower.readinessProbe.enabled }}
           readinessProbe:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -935,13 +935,6 @@ flower:
     ##
     minAvailable: ""
 
-  ## the value of the flower `--auth` argument
-  ##
-  ## NOTE:
-  ## - see flower docs: https://flower.readthedocs.io/en/latest/auth.html#google-oauth-2-0
-  ##
-  oauthDomains: ""
-
   ## the name of a pre-created secret containing the basic authentication value for flower
   ##
   ## NOTE:


### PR DESCRIPTION
**What issues does your PR fix?**

- resolves https://github.com/airflow-helm/charts/issues/382


**What does your PR do?**

- Removes the `flower.oauthDomains` value, for the reasons described in:
   - https://github.com/airflow-helm/charts/issues/382


## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
