### PR TITLE
fix: always include `airflow.env` last

### DIFF
--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -49,9 +49,10 @@ spec:
       envFrom:
         {{- include "airflow.envFrom" . | indent 8 }}
       env:
-        {{- include "airflow.env" . | indent 8 }}
         - name: AIRFLOW__CORE__EXECUTOR
           value: LocalExecutor
+        {{- /* this has user-defined variables, so must be included BELOW (so the ABOVE `env` take precedence) */ -}}
+        {{- include "airflow.env" . | indent 8 }}
       ports: []
       command: []
       args: []

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -162,8 +162,6 @@ EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release 
   envFrom:
     {{- include "airflow.envFrom" . | indent 4 }}
   env:
-    {{- include "airflow.env" . | indent 4 }}
-    {{- /* we define our GIT_XXXX configs BELOW any user configs (so ours take precidence) */ -}}
     {{- if .sync_one_time }}
     - name: GIT_SYNC_ONE_TIME
       value: "true"
@@ -215,6 +213,8 @@ EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release 
           name: {{ .Values.dags.gitSync.httpSecret }}
           key: {{ .Values.dags.gitSync.httpSecretPasswordKey }}
     {{- end }}
+    {{- /* this has user-defined variables, so must be included BELOW (so the ABOVE `env` take precedence) */ -}}
+    {{- include "airflow.env" . | indent 4 }}
   volumeMounts:
     - name: dags-data
       mountPath: /dags
@@ -403,6 +403,15 @@ The list of `env` for web/scheduler/worker/flower Pods
 - name: REDIS_PASSWORD
   value: ""
 {{- end }}
+{{- end }}
+
+{{- /* set AIRFLOW__CELERY__FLOWER_BASIC_AUTH */ -}}
+{{- if .Values.flower.basicAuthSecret }}
+- name: AIRFLOW__CELERY__FLOWER_BASIC_AUTH
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.flower.basicAuthSecret }}
+      key: {{ .Values.flower.basicAuthSecretKey }}
 {{- end }}
 
 {{- /* user-defined environment variables */ -}}

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -92,13 +92,6 @@ spec:
             {{- include "airflow.envFrom" . | indent 12 }}
           env:
             {{- include "airflow.env" . | indent 12 }}
-            {{- if .Values.flower.basicAuthSecret }}
-            - name: AIRFLOW__CELERY__FLOWER_BASIC_AUTH
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.flower.basicAuthSecret }}
-                  key: {{ .Values.flower.basicAuthSecretKey }}
-            {{- end }}
           ports:
             - name: flower
               containerPort: 5555


### PR DESCRIPTION
**What issues does your PR fix?**

- resolves https://github.com/airflow-helm/charts/issues/384


**What does your PR do?**

- Implements the change described in:
   - https://github.com/airflow-helm/charts/issues/384

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
