### PR TITLE
feat: use `/entrypoint` when `airflow.legacyCommands=false`

### DIFF
--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -49,6 +49,12 @@ spec:
       envFrom:
         {{- include "airflow.envFrom" . | indent 8 }}
       env:
+        {{- if not .Values.airflow.legacyCommands }}
+        ## enable the `/entrypoint` db connection check
+        - name: CONNECTION_CHECK_MAX_COUNT
+          value: "20"
+        {{- end }}
+        ## KubernetesExecutor Pods use LocalExecutor internally
         - name: AIRFLOW__CORE__EXECUTOR
           value: LocalExecutor
         {{- /* this has user-defined variables, so must be included BELOW (so the ABOVE `env` take precedence) */ -}}

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -97,8 +97,7 @@ spec:
               containerPort: 5555
               protocol: TCP
           command:
-            - "/usr/bin/dumb-init"
-            - "--"
+            {{- include "airflow.command" . | indent 12 }}
           args:
             - "bash"
             - "-c"
@@ -115,7 +114,7 @@ spec:
             failureThreshold: {{ .Values.flower.readinessProbe.failureThreshold }}
             exec:
               command:
-                - "/bin/bash"
+                - "bash"
                 - "-c"
                 {{- if or (.Values.flower.basicAuthSecret) (.Values.airflow.config.AIRFLOW__CELERY__FLOWER_BASIC_AUTH) }}
                 - "exec curl --user $AIRFLOW__CELERY__FLOWER_BASIC_AUTH 'http://localhost:5555{{ .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX }}'"
@@ -131,7 +130,7 @@ spec:
             failureThreshold: {{ .Values.flower.livenessProbe.failureThreshold }}
             exec:
               command:
-                - "/bin/bash"
+                - "bash"
                 - "-c"
                 {{- if or (.Values.flower.basicAuthSecret) (.Values.airflow.config.AIRFLOW__CELERY__FLOWER_BASIC_AUTH) }}
                 - "exec curl --user $AIRFLOW__CELERY__FLOWER_BASIC_AUTH 'http://localhost:5555{{ .Values.airflow.config.AIRFLOW__CELERY__FLOWER_URL_PREFIX }}'"

--- a/charts/airflow/templates/jobs/job-upgrade-db.yaml
+++ b/charts/airflow/templates/jobs/job-upgrade-db.yaml
@@ -47,8 +47,7 @@ spec:
           env:
             {{- include "airflow.env" . | indent 12 }}
           command:
-            - "/usr/bin/dumb-init"
-            - "--"
+            {{- include "airflow.command" . | indent 12 }}
           args:
             - "bash"
             - "-c"

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -107,8 +107,7 @@ spec:
           env:
             {{- include "airflow.env" . | indent 12 }}
           command:
-            - "/usr/bin/dumb-init"
-            - "--"
+            {{- include "airflow.command" . | indent 12 }}
           args:
             - "bash"
             - "-c"

--- a/charts/airflow/templates/sync/sync-connections-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-connections-deployment.yaml
@@ -90,8 +90,7 @@ spec:
           env:
             {{- include "airflow.env" . | indent 12 }}
           command:
-            - "/usr/bin/dumb-init"
-            - "--"
+            {{- include "airflow.command" . | indent 12 }}
           args:
             - "python"
             - "-u"

--- a/charts/airflow/templates/sync/sync-connections-job.yaml
+++ b/charts/airflow/templates/sync/sync-connections-job.yaml
@@ -84,8 +84,7 @@ spec:
           env:
             {{- include "airflow.env" . | indent 12 }}
           command:
-            - "/usr/bin/dumb-init"
-            - "--"
+            {{- include "airflow.command" . | indent 12 }}
           args:
             - "python"
             - "-u"

--- a/charts/airflow/templates/sync/sync-pools-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-pools-deployment.yaml
@@ -90,8 +90,7 @@ spec:
           env:
             {{- include "airflow.env" . | indent 12 }}
           command:
-            - "/usr/bin/dumb-init"
-            - "--"
+            {{- include "airflow.command" . | indent 12 }}
           args:
             - "python"
             - "-u"

--- a/charts/airflow/templates/sync/sync-pools-job.yaml
+++ b/charts/airflow/templates/sync/sync-pools-job.yaml
@@ -84,8 +84,7 @@ spec:
           env:
             {{- include "airflow.env" . | indent 12 }}
           command:
-            - "/usr/bin/dumb-init"
-            - "--"
+            {{- include "airflow.command" . | indent 12 }}
           args:
             - "python"
             - "-u"

--- a/charts/airflow/templates/sync/sync-users-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-users-deployment.yaml
@@ -90,8 +90,7 @@ spec:
           env:
             {{- include "airflow.env" . | indent 12 }}
           command:
-            - "/usr/bin/dumb-init"
-            - "--"
+            {{- include "airflow.command" . | indent 12 }}
           args:
             - "python"
             - "-u"

--- a/charts/airflow/templates/sync/sync-users-job.yaml
+++ b/charts/airflow/templates/sync/sync-users-job.yaml
@@ -84,8 +84,7 @@ spec:
           env:
             {{- include "airflow.env" . | indent 12 }}
           command:
-            - "/usr/bin/dumb-init"
-            - "--"
+            {{- include "airflow.command" . | indent 12 }}
           args:
             - "python"
             - "-u"

--- a/charts/airflow/templates/sync/sync-variables-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-variables-deployment.yaml
@@ -90,8 +90,7 @@ spec:
           env:
             {{- include "airflow.env" . | indent 12 }}
           command:
-            - "/usr/bin/dumb-init"
-            - "--"
+            {{- include "airflow.command" . | indent 12 }}
           args:
             - "python"
             - "-u"

--- a/charts/airflow/templates/sync/sync-variables-job.yaml
+++ b/charts/airflow/templates/sync/sync-variables-job.yaml
@@ -84,8 +84,7 @@ spec:
           env:
             {{- include "airflow.env" . | indent 12 }}
           command:
-            - "/usr/bin/dumb-init"
-            - "--"
+            {{- include "airflow.command" . | indent 12 }}
           args:
             - "python"
             - "-u"

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -100,8 +100,7 @@ spec:
           env:
             {{- include "airflow.env" . | indent 12 }}
           command:
-            - "/usr/bin/dumb-init"
-            - "--"
+            {{- include "airflow.command" . | indent 12 }}
           args:
             - "bash"
             - "-c"

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -147,11 +147,11 @@ spec:
               containerPort: 8793
               protocol: TCP
           command:
-            - "/usr/bin/dumb-init"
-            - "--"
-          args:
+            {{- include "airflow.command" . | indent 12 }}
+            ## required because `/entrypoint` only passes "bash" / "python", and our `lifecycle.preStop` uses "timeout"
             - "bash"
             - "-c"
+          args:
             {{- if .Values.airflow.legacyCommands }}
             - "exec airflow worker"
             {{- else }}


### PR DESCRIPTION
**What issues does your PR fix?**

- resolves https://github.com/airflow-helm/charts/issues/336

**What does your PR do?**

- Start using the default `/entrypoint` for Airflow 2.0+ (when `airflow.legacyCommands=false`).
- First step towards out-of-the-box OpenShift support (`/entrypoint` handles most OpenShift issues as of airflow `2.1.2`)

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
