### PR TITLE
refactor: set default `airflow.image.gid=0`

### DIFF
--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -15,7 +15,7 @@ airflow:
     pullPolicy: IfNotPresent
     pullSecret: ""
     uid: 50000
-    gid: 50000
+    gid: 0
 
   ## the airflow executor type to use
   ##


### PR DESCRIPTION
**What issues does your PR fix?**

- resolves https://github.com/airflow-helm/charts/issues/337

**What does your PR do?**

- Sets the default `airflow.image.gid` to `0`.


## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
