### PR TITLE
fix: include git-sync in all Deployments

### DIFF
--- a/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
@@ -79,11 +79,11 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- /* we include git-sync so `check_db` has access to any plugins stored there (note, `sync_one_time=true`) */ -}}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: db-migrations
           {{- include "airflow.image" . | indent 10 }}
@@ -104,6 +104,10 @@ spec:
             - name: scripts
               mountPath: /mnt/scripts
               readOnly: true
+        {{- if .Values.dags.gitSync.enabled }}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
+        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- end }}
       volumes:
         {{- $volumes | indent 8 }}
         - name: scripts

--- a/charts/airflow/templates/db-migrations/db-migrations-job.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-job.yaml
@@ -73,11 +73,11 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- /* we include git-sync so `check_db` has access to any plugins stored there (note, `sync_one_time=true`) */ -}}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: db-migrations
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -83,6 +83,10 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
+        {{- if .Values.dags.gitSync.enabled }}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
@@ -144,6 +148,10 @@ spec:
           volumeMounts:
             {{- $volumeMounts | indent 12 }}
           {{- end }}
+        {{- if .Values.dags.gitSync.enabled }}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
+        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -94,11 +94,11 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- if .Values.dags.gitSync.enabled }}
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- if .Values.scheduler.extraInitContainers }}
         {{- toYaml .Values.scheduler.extraInitContainers | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/sync/sync-connections-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-connections-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- /* we include git-sync so `check_db` & `wait_for_db_migrations` have access to any plugins stored there (note, `sync_one_time=true`) */ -}}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -110,6 +110,10 @@ spec:
               mountPath: "/mnt/templates"
               readOnly: true
             {{- end }}
+        {{- if .Values.dags.gitSync.enabled }}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
+        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- end }}
       volumes:
         {{- $volumes | indent 8 }}
         - name: scripts

--- a/charts/airflow/templates/sync/sync-connections-job.yaml
+++ b/charts/airflow/templates/sync/sync-connections-job.yaml
@@ -74,7 +74,7 @@ spec:
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- /* we include git-sync so `check_db` & `wait_for_db_migrations` have access to any plugins stored there (note, `sync_one_time=true`) */ -}}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}

--- a/charts/airflow/templates/sync/sync-pools-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-pools-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- /* we include git-sync so `check_db` & `wait_for_db_migrations` have access to any plugins stored there (note, `sync_one_time=true`) */ -}}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -105,6 +105,10 @@ spec:
             - name: scripts
               mountPath: /mnt/scripts
               readOnly: true
+        {{- if .Values.dags.gitSync.enabled }}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
+        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- end }}
       volumes:
         {{- $volumes | indent 8 }}
         - name: scripts

--- a/charts/airflow/templates/sync/sync-pools-job.yaml
+++ b/charts/airflow/templates/sync/sync-pools-job.yaml
@@ -74,7 +74,7 @@ spec:
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- /* we include git-sync so `check_db` & `wait_for_db_migrations` have access to any plugins stored there (note, `sync_one_time=true`) */ -}}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}

--- a/charts/airflow/templates/sync/sync-users-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-users-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- /* we include git-sync so `check_db` & `wait_for_db_migrations` have access to any plugins stored there (note, `sync_one_time=true`) */ -}}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -110,6 +110,10 @@ spec:
               mountPath: "/mnt/templates"
               readOnly: true
             {{- end }}
+        {{- if .Values.dags.gitSync.enabled }}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
+        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- end }}
       volumes:
         {{- $volumes | indent 8 }}
         - name: scripts

--- a/charts/airflow/templates/sync/sync-users-job.yaml
+++ b/charts/airflow/templates/sync/sync-users-job.yaml
@@ -74,7 +74,7 @@ spec:
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- /* we include git-sync so `check_db` & `wait_for_db_migrations` have access to any plugins stored there (note, `sync_one_time=true`) */ -}}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}

--- a/charts/airflow/templates/sync/sync-variables-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-variables-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- /* we include git-sync so `check_db` & `wait_for_db_migrations` have access to any plugins stored there (note, `sync_one_time=true`) */ -}}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -110,6 +110,10 @@ spec:
               mountPath: "/mnt/templates"
               readOnly: true
             {{- end }}
+        {{- if .Values.dags.gitSync.enabled }}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
+        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- end }}
       volumes:
         {{- $volumes | indent 8 }}
         - name: scripts

--- a/charts/airflow/templates/sync/sync-variables-job.yaml
+++ b/charts/airflow/templates/sync/sync-variables-job.yaml
@@ -74,7 +74,7 @@ spec:
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- /* we include git-sync so `check_db` & `wait_for_db_migrations` have access to any plugins stored there (note, `sync_one_time=true`) */ -}}
+        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -86,11 +86,11 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- if .Values.dags.gitSync.enabled }}
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: airflow-web
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -91,11 +91,11 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- if .Values.dags.gitSync.enabled }}
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: airflow-worker
           {{- include "airflow.image" . | indent 10 }}


### PR DESCRIPTION
**What issues does your PR fix?**

- resolves https://github.com/airflow-helm/charts/issues/375
- resolves https://github.com/airflow-helm/charts/issues/276

**What does your PR do?**

- Allow "airflow plugins" and "python packages" to be stored in the DAGs git repo:
  - Includes the `git-sync` init-container and sidecar container in all Deployments
  - Orders the init-containers so that `git-sync` comes before `check_db` and `wait_for_db_migrations` 

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
