### PR TITLE
fix: pgbouncer config for non-default database name

### DIFF
--- a/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
+++ b/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
@@ -4,9 +4,9 @@ Define the content of the `pgbouncer.ini` config file.
 {{- define "airflow.pgbouncer.pgbouncer.ini" }}
 [databases]
 {{- if .Values.postgresql.enabled }}
-airflow = host={{ printf "%s.%s.svc.cluster.local" (include "airflow.postgresql.fullname" .) (.Release.Namespace) }} port=5432
+* = host={{ printf "%s.%s.svc.cluster.local" (include "airflow.postgresql.fullname" .) (.Release.Namespace) }} port=5432
 {{- else }}
-airflow = host={{ .Values.externalDatabase.host }} port={{ .Values.externalDatabase.port }}
+* = host={{ .Values.externalDatabase.host }} port={{ .Values.externalDatabase.port }}
 {{- end }}
 
 [pgbouncer]


### PR DESCRIPTION
**What issues does your PR fix?**

- resolves https://github.com/airflow-helm/charts/issues/396

**What does your PR do?**

- Fixes PgBouncer with `postgresql.postgresqlDatabase` or `externalDatabase.database` set to a value other than `airflow`
- Implements the changes described in:
   - https://github.com/airflow-helm/charts/issues/396

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
