### PR TITLE
fix: only gen self-signed certs for pgbouncer client configs

### DIFF
--- a/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
+++ b/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
@@ -27,16 +27,24 @@ log_connections = {{ .Values.pgbouncer.logConnections }}
 ## CLIENT TLS SETTINGS ##
 client_tls_sslmode = {{ .Values.pgbouncer.clientSSL.mode }}
 client_tls_ciphers = {{ .Values.pgbouncer.clientSSL.ciphers }}
+{{- if .Values.pgbouncer.clientSSL.caFile.existingSecret }}
 client_tls_ca_file = /home/pgbouncer/certs/client-ca.crt
+{{- end }}
 client_tls_key_file = /home/pgbouncer/certs/client.key
 client_tls_cert_file = /home/pgbouncer/certs/client.crt
 
 ## SERVER TLS SETTINGS ##
 server_tls_sslmode = {{ .Values.pgbouncer.serverSSL.mode }}
 server_tls_ciphers = {{ .Values.pgbouncer.serverSSL.ciphers }}
+{{- if .Values.pgbouncer.serverSSL.caFile.existingSecret }}
 server_tls_ca_file = /home/pgbouncer/certs/server-ca.crt
+{{- end }}
+{{- if .Values.pgbouncer.serverSSL.keyFile.existingSecret }}
 server_tls_key_file = /home/pgbouncer/certs/server.key
+{{- end }}
+{{- if .Values.pgbouncer.serverSSL.certFile.existingSecret }}
 server_tls_cert_file = /home/pgbouncer/certs/server.crt
+{{- end }}
 
 {{- end }}
 

--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -143,15 +143,11 @@ spec:
         - name: pgbouncer-certs
           projected:
             sources:
-              {{- if or (not .Values.pgbouncer.clientSSL.caFile.existingSecret) (not .Values.pgbouncer.clientSSL.keyFile.existingSecret) (not .Values.pgbouncer.clientSSL.certFile.existingSecret) }}
-              ## CLIENT TLS FILES (AUTO GENERATED)
+              {{- if or (not .Values.pgbouncer.clientSSL.keyFile.existingSecret) (not .Values.pgbouncer.clientSSL.certFile.existingSecret) }}
+              ## CLIENT TLS FILES (CHART GENERATED)
               - secret:
                   name: {{ include "airflow.fullname" . }}-pgbouncer-certs
                   items:
-                    {{- if not .Values.pgbouncer.clientSSL.caFile.existingSecret }}
-                    - key: client-ca.crt
-                      path: client-ca.crt
-                    {{- end }}
                     {{- if not .Values.pgbouncer.clientSSL.keyFile.existingSecret }}
                     - key: client.key
                       path: client.key
@@ -162,27 +158,8 @@ spec:
                     {{- end }}
               {{- end }}
 
-              {{- if or (not .Values.pgbouncer.serverSSL.caFile.existingSecret) (not .Values.pgbouncer.serverSSL.keyFile.existingSecret) (not .Values.pgbouncer.serverSSL.certFile.existingSecret) }}
-              ## SERVER TLS FILES (AUTO GENERATED)
-              - secret:
-                  name: {{ include "airflow.fullname" . }}-pgbouncer-certs
-                  items:
-                    {{- if not .Values.pgbouncer.serverSSL.caFile.existingSecret }}
-                    - key: server-ca.crt
-                      path: server-ca.crt
-                    {{- end }}
-                    {{- if not .Values.pgbouncer.serverSSL.keyFile.existingSecret }}
-                    - key: server.key
-                      path: server.key
-                    {{- end }}
-                    {{- if not .Values.pgbouncer.serverSSL.certFile.existingSecret }}
-                    - key: server.crt
-                      path: server.crt
-                    {{- end }}
-              {{- end }}
-
               {{- if or (.Values.pgbouncer.clientSSL.caFile.existingSecret) (.Values.pgbouncer.clientSSL.keyFile.existingSecret) (.Values.pgbouncer.clientSSL.certFile.existingSecret) }}
-              ## CLIENT TLS FILES (USER CUSTOM)
+              ## CLIENT TLS FILES (USER PROVIDED)
               {{- if .Values.pgbouncer.clientSSL.caFile.existingSecret }}
               - secret:
                   name: {{ .Values.pgbouncer.clientSSL.caFile.existingSecret }}
@@ -207,7 +184,7 @@ spec:
               {{- end }}
 
               {{- if or (.Values.pgbouncer.serverSSL.caFile.existingSecret) (.Values.pgbouncer.serverSSL.keyFile.existingSecret) (.Values.pgbouncer.serverSSL.certFile.existingSecret) }}
-              ## SERVER TLS FILES (USER CUSTOM)
+              ## SERVER TLS FILES (USER PROVIDED)
               {{- if .Values.pgbouncer.serverSSL.caFile.existingSecret }}
               - secret:
                   name: {{ .Values.pgbouncer.serverSSL.caFile.existingSecret }}

--- a/charts/airflow/templates/pgbouncer/pgbouncer-secret-certs.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-secret-certs.yaml
@@ -1,10 +1,6 @@
-{{- $any_client_needed :=  or (not .Values.pgbouncer.clientSSL.caFile.existingSecret) (not .Values.pgbouncer.clientSSL.keyFile.existingSecret) (not .Values.pgbouncer.clientSSL.certFile.existingSecret) }}
-{{- $any_server_needed :=  or (not .Values.pgbouncer.serverSSL.caFile.existingSecret) (not .Values.pgbouncer.serverSSL.keyFile.existingSecret) (not .Values.pgbouncer.serverSSL.certFile.existingSecret) }}
-{{- if and (include "airflow.pgbouncer.should_use" .) (or $any_client_needed $any_server_needed) }}
-{{- $client_ca := genCA "client-ca" 365 }}
-{{- $client_cert := genSignedCert "localhost" nil nil 365 $client_ca }}
-{{- $server_ca := genCA "server-ca" 365 }}
-{{- $server_cert := genSignedCert "localhost" nil nil 365 $server_ca }}
+{{- $self_signed_needed :=  or (not .Values.pgbouncer.clientSSL.keyFile.existingSecret) (not .Values.pgbouncer.clientSSL.certFile.existingSecret) }}
+{{- if and (include "airflow.pgbouncer.should_use" .) ($self_signed_needed) }}
+{{- $client_cert := genSelfSignedCert "localhost" nil nil 365 }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -16,23 +12,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{- if not .Values.pgbouncer.clientSSL.caFile.existingSecret }}
-  client-ca.crt: {{ $client_ca.Cert | b64enc | quote }}
-  {{- end }}
   {{- if not .Values.pgbouncer.clientSSL.keyFile.existingSecret }}
   client.key: {{ $client_cert.Key | b64enc | quote }}
   {{- end }}
   {{- if not .Values.pgbouncer.clientSSL.certFile.existingSecret }}
   client.crt: {{ $client_cert.Cert  | b64enc | quote }}
-  {{- end }}
-
-  {{- if not .Values.pgbouncer.serverSSL.caFile.existingSecret }}
-  server-ca.crt: {{ $server_ca.Cert | b64enc | quote }}
-  {{- end }}
-  {{- if not .Values.pgbouncer.serverSSL.keyFile.existingSecret }}
-  server.key: {{ $server_cert.Key | b64enc | quote }}
-  {{- end }}
-  {{- if not .Values.pgbouncer.serverSSL.certFile.existingSecret }}
-  server.crt: {{ $server_cert.Cert | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1462,7 +1462,6 @@ pgbouncer:
   logConnections: 0
 
   ## ssl configs for: clients -> pgbouncer
-  ## - if `caFile`, `keyFile`, `certFile` are not provided, we auto generate self-signed certificates
   ##
   clientSSL:
     ## sets pgbouncer config: `client_tls_sslmode`
@@ -1480,19 +1479,20 @@ pgbouncer:
       existingSecretKey: root.crt
 
     ## sets pgbouncer config: `client_tls_key_file`
+    ## - [WARNING] a self-signed cert & key are generated if left empty
     ##
     keyFile:
       existingSecret: ""
       existingSecretKey: client.key
 
     ## sets pgbouncer config: `client_tls_cert_file`
+    ## - [WARNING] a self-signed cert & key are generated if left empty
     ##
     certFile:
       existingSecret: ""
       existingSecretKey: client.crt
 
   ## ssl configs for: pgbouncer -> postgres
-  ## - if `caFile`, `keyFile`, `certFile` are not provided, we auto generate self-signed certificates
   ##
   serverSSL:
     ## sets pgbouncer config: `server_tls_sslmode`


### PR DESCRIPTION
**What issues does your PR fix?**

- resolve https://github.com/airflow-helm/charts/issues/402

**What does your PR do?**

- Implements the changes described in:
   - https://github.com/airflow-helm/charts/issues/402
- Prevents errors like `routines:ssl3_read_bytes:tlsv1 alert unknown ca` in PgBouncer


## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
