### PR TITLE
fix: make flower affected by default nodeSelector, affinity, tolerations

### DIFF
--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.flower.enabled }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.flower.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.flower.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.flower.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.flower.securityContext) }}
 {{- $extraPipPackages := concat .Values.airflow.extraPipPackages .Values.flower.extraPipPackages }}
 {{- $extraVolumeMounts := .Values.flower.extraVolumeMounts }}
@@ -62,23 +65,23 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.airflow.image.pullSecret }}
       {{- end }}
-      {{- if .Values.flower.nodeSelector }}
+      {{- if $podNodeSelector }}
       nodeSelector:
-        {{- toYaml .Values.flower.nodeSelector | nindent 8 }}
+        {{- $podNodeSelector | nindent 8 }}
       {{- end }}
-      {{- if .Values.flower.affinity }}
+      {{- if $podAffinity }}
       affinity:
-        {{- toYaml .Values.flower.affinity | nindent 8 }}
+        {{- $podAffinity | nindent 8 }}
       {{- end }}
-      {{- if .Values.flower.tolerations }}
+      {{- if $podTolerations }}
       tolerations:
-        {{- toYaml .Values.flower.tolerations | nindent 8 }}
+        {{- $podTolerations | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       {{- if $podSecurityContext }}
       securityContext:
         {{- $podSecurityContext | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}


### PR DESCRIPTION
**What issues does your PR fix?**

- resolves https://github.com/airflow-helm/charts/issues/403

**What does your PR do?**

- Makes the flower Deployment affected by `airflow.{defaultNodeSelector,defaultAffinity,defaultTolerations}`

## Checklist
<!-- Place an '[x]' completed tasks -->
- [X] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
