### PR TITLE
feat: add `airflow.kubernetesPodTemplate.shareProcessNamespace` value

### DIFF
--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -22,6 +22,7 @@ spec:
     - name: {{ .Values.airflow.image.pullSecret }}
   {{- end }}
   serviceAccountName: {{ include "airflow.serviceAccountName" . }}
+  shareProcessNamespace: {{ .Values.airflow.kubernetesPodTemplate.shareProcessNamespace }}
   {{- if $podNodeSelector }}
   nodeSelector:
     {{- $podNodeSelector | nindent 4 }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -308,6 +308,12 @@ airflow:
     ##
     securityContext: {}
 
+    ## the shareProcessNamespace config for the Pod template
+    ## - docs for shareProcessNamespace:
+    ##   https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+    ##
+    shareProcessNamespace: false
+
     ## extra pip packages to install in the Pod template
     ##
     ## ____ EXAMPLE _______________


### PR DESCRIPTION
## What issues does your PR fix?

I was looking for a nice way to deal with secrets in airflow. As we already use Hashicorp Vault everywhere and are very happy with it I was looking for a good way to make airflow work with it.

There is a [Vault secret backend](https://airflow.apache.org/docs/apache-airflow-providers-hashicorp/stable/secrets-backends/hashicorp-vault.html#hashicorp-vault-secrets) in Airflow but it's very basic. The feature I mostly want to use is to get dynamic credentials for accessing databases, with credentials that will live the time of the pod (dag). For the rest, airflow vars and connections are fine.

I tried to use [Vault CSI](https://github.com/hashicorp/vault-csi-provider) but it's still early stage and also does not fulfill what I want to do. In the end, I just did what I do in other projects: using pod annotations to let vault inject a sidecar in the pod that will inject credentials and revokes them when the pod dies.

Unfortunately, this vault sidecar is meant to always run (running along with a web server or so) and does not work with k8s jobs would end. In order to make it work, I have to add yet another sidecar that will detect when the dag is done then send a signal to kill the vault container. Otherwise, the Pod containing the dag will move to an "unready" state forever as the vault container never dies. [relevant issue in vault project](https://github.com/hashicorp/vault/issues/11089)

I know this is quite a niche PR and quite hacky so you'll decide if it's worth merging. Maybe this PR could still help some people trying to do the same. I guess a proper way could be to change the airflow controller to kill the pod when it detects the Dag is done 🤷 

__Example using new `airflow.kubernetesPodTemplate.shareProcessNamespace` value:__

```yaml
airflow:
  [...]
  kubernetesPodTemplate:
    [...]
      # new value from this PR
      shareProcessNamespace: true

      # sidecar Vault container to inject secrets
      # (uses the shared process namepsace to kill itself when the task finishes)
      extraContainers:
        - name: vault-killer
          image: ubuntu
          command:
            - /bin/bash
            - '-c'
            - 'sleep 5 && while [[ $(pidof dumb-init) ]]; do sleep 5; done; kill -SIGTERM $(pidof vault) || echo "Vault is already gone."'
          resources:
            requests:
              cpu: 30m
              memory: 50Mi
            limits:
              cpu: 100m
              memory: 100Mi
```

## What does your PR do?

- Adds a `airflow.kubernetesPodTemplate.shareProcessNamespace` value to allow enabling the [shareProcessNamespace](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) feature on the KubernetesExecutor pod_template.

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)