### PR TITLE
feat: add `airflow.clusterDomain` value

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1459,6 +1459,7 @@ Parameter | Description | Default
 `airflow.extraContainers` | extra containers for the airflow Pods | `[]`
 `airflow.extraVolumeMounts` | extra VolumeMounts for the airflow Pods | `[]`
 `airflow.extraVolumes` | extra Volumes for the airflow Pods | `[]`
+`airflow.clusterDomain` | kubernetes cluster domain name | `cluster.local`
 `airflow.localSettings.*` | airflow_local_settings.py | `<see values.yaml>`
 `airflow.kubernetesPodTemplate.*` | pod_template.yaml | `<see values.yaml>`
 `airflow.dbMigrations.*` | db-migrations Deployment | `<see values.yaml>`

--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -19,10 +19,10 @@ data:
   ## ================
   ## database host/port
   {{- if include "airflow.pgbouncer.should_use" . }}
-  DATABASE_HOST: {{ printf "%s-pgbouncer.%s.svc.cluster.local" (include "airflow.fullname" .) (.Release.Namespace) | b64enc | quote }}
+  DATABASE_HOST: {{ printf "%s-pgbouncer.%s.svc.%s" (include "airflow.fullname" .) (.Release.Namespace) (.Values.airflow.clusterDomain) | b64enc | quote }}
   DATABASE_PORT: {{ "6432" | b64enc | quote }}
   {{- else if .Values.postgresql.enabled }}
-  DATABASE_HOST: {{ printf "%s.%s.svc.cluster.local" (include "airflow.postgresql.fullname" .) (.Release.Namespace) | b64enc | quote }}
+  DATABASE_HOST: {{ printf "%s.%s.svc.%s" (include "airflow.postgresql.fullname" .) (.Release.Namespace) (.Values.airflow.clusterDomain) | b64enc | quote }}
   DATABASE_PORT: {{ "5432" | b64enc | quote }}
   {{- else }}
   DATABASE_HOST: {{ .Values.externalDatabase.host | b64enc | quote }}
@@ -72,7 +72,7 @@ data:
   {{- if include "airflow.executor.celery_like" . }}
   ## connection string components
   {{- if .Values.redis.enabled }}
-  REDIS_HOST: {{ printf "%s-master.%s.svc.cluster.local" (include "airflow.redis.fullname" .) (.Release.Namespace) | b64enc | quote }}
+  REDIS_HOST: {{ printf "%s-master.%s.svc.%s" (include "airflow.redis.fullname" .) (.Release.Namespace) (.Values.airflow.clusterDomain) | b64enc | quote }}
   REDIS_PORT: {{ "6379" | b64enc | quote }}
   REDIS_DBNUM: {{ "1" | b64enc | quote }}
   {{- else }}

--- a/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
+++ b/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
@@ -4,7 +4,7 @@ Define the content of the `pgbouncer.ini` config file.
 {{- define "airflow.pgbouncer.pgbouncer.ini" }}
 [databases]
 {{- if .Values.postgresql.enabled }}
-* = host={{ printf "%s.%s.svc.cluster.local" (include "airflow.postgresql.fullname" .) (.Release.Namespace) }} port=5432
+* = host={{ printf "%s.%s.svc.%s" (include "airflow.postgresql.fullname" .) (.Release.Namespace) (.Values.airflow.clusterDomain) }} port=5432
 {{- else }}
 * = host={{ .Values.externalDatabase.host }} port={{ .Values.externalDatabase.port }}
 {{- end }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -232,6 +232,10 @@ airflow:
   ##
   extraVolumes: []
 
+  ## kubernetes cluster domain name configured in the kubelet with clusterDomain option
+  ##
+  clusterDomain: "cluster.local"
+
   ########################################
   ## FILE | airflow_local_settings.py
   ########################################

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -232,7 +232,11 @@ airflow:
   ##
   extraVolumes: []
 
-  ## kubernetes cluster domain name configured in the kubelet with clusterDomain option
+  ## kubernetes cluster domain name
+  ## - configured in the kubelet with `--cluster-domain` flag (deprecated):
+  ##   https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
+  ## - or configured in the kubelet with configuration file `clusterDomain` option:
+  ##   https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
   ##
   clusterDomain: "cluster.local"
 


### PR DESCRIPTION
## What issues does your PR fix?

- fixes https://github.com/airflow-helm/charts/issues/476

## What does your PR do?

- Adds a `airflow.clusterDomain` value (default: `cluster.local`) to allow setting the Kubelet `clusterDomain` to non-standard values.

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated