### PR TITLE
feat: add `airflow.kubernetesPodTemplate.extraInitContainers`

### DIFF
--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -38,13 +38,16 @@ spec:
   securityContext:
     {{- $podSecurityContext | nindent 4 }}
   {{- end }}
-  {{- if or ($extraPipPackages) (.Values.dags.gitSync.enabled) }}
+  {{- if or ($extraPipPackages) (.Values.dags.gitSync.enabled) (.Values.airflow.kubernetesPodTemplate.extraInitContainers) }}
   initContainers:
     {{- if $extraPipPackages }}
     {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 4 }}
     {{- end }}
     {{- if .Values.dags.gitSync.enabled }}
     {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 4 }}
+    {{- end }}
+    {{- if .Values.airflow.kubernetesPodTemplate.extraInitContainers }}
+    {{- toYaml .Values.airflow.kubernetesPodTemplate.extraInitContainers | nindent 4 }}
     {{- end }}
   {{- end }}
   containers:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -316,6 +316,12 @@ airflow:
     ##
     extraPipPackages: []
 
+    ## extra init-containers for the Pod template
+    ## - spec of Container:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+    ##
+    extraInitContainers: []
+
     ## extra VolumeMounts for the Pod template
     ## - spec for VolumeMount:
     ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core


### PR DESCRIPTION
## What issues does your PR fix?

N/A

## What does your PR do?

- Adds the `airflow.kubernetesPodTemplate.extraInitContainers` value to specify extra KubernetesExecutor init-containers


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated