### PR TITLE
Enabled extra containers for pod template

### DIFF
--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -74,6 +74,10 @@ spec:
       volumeMounts:
         {{- $volumeMounts | indent 8 }}
       {{- end }}
+    
+    {{- if .Values.airflow.kubernetesPodTemplate.extraContainers }}
+    {{- toYaml .Values.airflow.kubernetesPodTemplate.extraContainers | nindent 4 }}
+    {{- end }}
   {{- if $volumes }}
   volumes:
     {{- $volumes | indent 4 }}


### PR DESCRIPTION
This allows to have side cars for the pod executor. In our case we need it to mount dags folder from S3 using s3fs.

<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


**What issues does your PR fix?**

- It adds a new feature


**What does your PR do?**

- Uses a new config option .airflow.kubernetesPodTemplate.extraContainers to add any number of side cars to the pod executor.


## Checklist
<!-- Place an '[x]' completed tasks -->
- [ ] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [ ] Commits are [squashed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#squash-commits) (only do this if appropriate)
- [ ] Chart [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning) (only do this if releasing a new version)
- [ ] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [ ] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
