### PR TITLE
fix: typo in `GIT_SYNC_MAX_SYNC_FAILURES` envvar

### DIFF
--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -225,7 +225,7 @@ EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release 
       value: {{ .Values.dags.gitSync.syncTimeout | quote }}
     - name: GIT_SYNC_ADD_USER
       value: "true"
-    - name: GIT_SYNC_MAX_FAILURES
+    - name: GIT_SYNC_MAX_SYNC_FAILURES
       value: {{ .Values.dags.gitSync.maxFailures | quote }}
     {{- if .Values.dags.gitSync.sshSecret }}
     - name: GIT_SYNC_SSH


### PR DESCRIPTION
**What does your PR do?**

- `GIT_SYNC_MAX_SYNC_FAILURES` is the [correct environment variable name](https://github.com/kubernetes/git-sync#parameters)

## Checklist
<!-- Place an '[x]' completed tasks -->
- [x] Commits are [signed](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Chart [documentation updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
