### PR TITLE
feat: allow labels on `sync` and `db-migrations` Deployments/Jobs

### DIFF
--- a/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.airflow.dbMigrations.labels }}
+    {{- toYaml .Values.airflow.dbMigrations.labels | nindent 4 }}
+    {{- end }}
   {{- if .Values.airflow.dbMigrations.annotations }}
   annotations:
     {{- toYaml .Values.airflow.dbMigrations.annotations | nindent 4 }}

--- a/charts/airflow/templates/db-migrations/db-migrations-job.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-job.yaml
@@ -16,6 +16,9 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.airflow.dbMigrations.labels }}
+    {{- toYaml .Values.airflow.dbMigrations.labels | nindent 4 }}
+    {{- end }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "-100"

--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -13,6 +13,9 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.pgbouncer.labels }}
+    {{- toYaml .Values.pgbouncer.labels | nindent 4 }}
+    {{- end }}
   {{- if .Values.pgbouncer.annotations }}
   annotations:
   {{- toYaml .Values.pgbouncer.annotations | nindent 4 }}

--- a/charts/airflow/templates/sync/sync-connections-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-connections-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.airflow.sync.labels }}
+    {{- toYaml .Values.airflow.sync.labels | nindent 4 }}
+    {{- end }}
   {{- if .Values.airflow.sync.annotations }}
   annotations:
     {{- toYaml .Values.airflow.sync.annotations | nindent 4 }}

--- a/charts/airflow/templates/sync/sync-connections-job.yaml
+++ b/charts/airflow/templates/sync/sync-connections-job.yaml
@@ -16,6 +16,9 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.airflow.sync.labels }}
+    {{- toYaml .Values.airflow.sync.labels | nindent 4 }}
+    {{- end }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "0"

--- a/charts/airflow/templates/sync/sync-pools-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-pools-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.airflow.sync.labels }}
+    {{- toYaml .Values.airflow.sync.labels | nindent 4 }}
+    {{- end }}
   {{- if .Values.airflow.sync.annotations }}
   annotations:
     {{- toYaml .Values.airflow.sync.annotations | nindent 4 }}

--- a/charts/airflow/templates/sync/sync-pools-job.yaml
+++ b/charts/airflow/templates/sync/sync-pools-job.yaml
@@ -16,8 +16,8 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    {{- if .Values.airflow.sync.podLabels }}
-    {{- toYaml .Values.airflow.sync.podLabels | nindent 4 }}
+    {{- if .Values.airflow.sync.labels }}
+    {{- toYaml .Values.airflow.sync.labels | nindent 4 }}
     {{- end }}
   annotations:
     helm.sh/hook: post-install,post-upgrade

--- a/charts/airflow/templates/sync/sync-pools-job.yaml
+++ b/charts/airflow/templates/sync/sync-pools-job.yaml
@@ -16,6 +16,9 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.airflow.sync.podLabels }}
+    {{- toYaml .Values.airflow.sync.podLabels | nindent 4 }}
+    {{- end }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "0"

--- a/charts/airflow/templates/sync/sync-users-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-users-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.airflow.sync.labels }}
+    {{- toYaml .Values.airflow.sync.labels | nindent 4 }}
+    {{- end }}
   {{- if .Values.airflow.sync.annotations }}
   annotations:
     {{- toYaml .Values.airflow.sync.annotations | nindent 4 }}

--- a/charts/airflow/templates/sync/sync-users-job.yaml
+++ b/charts/airflow/templates/sync/sync-users-job.yaml
@@ -16,6 +16,9 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.airflow.sync.labels }}
+    {{- toYaml .Values.airflow.sync.labels | nindent 4 }}
+    {{- end }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "0"

--- a/charts/airflow/templates/sync/sync-variables-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-variables-deployment.yaml
@@ -16,6 +16,9 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.airflow.sync.labels }}
+    {{- toYaml .Values.airflow.sync.labels | nindent 4 }}
+    {{- end }}
   {{- if .Values.airflow.sync.annotations }}
   annotations:
     {{- toYaml .Values.airflow.sync.annotations | nindent 4 }}

--- a/charts/airflow/templates/sync/sync-variables-job.yaml
+++ b/charts/airflow/templates/sync/sync-variables-job.yaml
@@ -16,6 +16,9 @@ metadata:
     chart: {{ include "airflow.labels.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.airflow.sync.labels }}
+    {{- toYaml .Values.airflow.sync.labels | nindent 4 }}
+    {{- end }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "0"

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -374,6 +374,10 @@ airflow:
     ##
     securityContext: {}
 
+    ## Labels for the db-migrations Deployment
+    ##
+    labels: {}
+
     ## Pod labels for the db-migrations Deployment
     ##
     podLabels: {}
@@ -430,6 +434,10 @@ airflow:
     ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
     ##
     securityContext: {}
+
+    ## Labels for the sync Deployments/Jobs
+    ##
+    labels: {}
 
     ## Pod labels for the sync Deployments/Jobs
     ##

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1405,7 +1405,7 @@ pgbouncer:
   ##
   securityContext: {}
 
-  ## labels for the pgbouncer Deployment
+  ## Labels for the pgbouncer Deployment
   ##
   labels: {}
 


### PR DESCRIPTION
## What issues does your PR fix?

- resolves https://github.com/airflow-helm/charts/issues/466
- resolves https://github.com/airflow-helm/charts/issues/447

## What does your PR do?

- Adds the following values to set labels on the `sync` and `db-migrations` Deployments/Jobs:
   - `airflow.dbMigrations.labels`
   - `airflow.sync.labels`
- Fixed the `pgbouncer.labels` value so that it is respected

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated