### PR TITLE
feat: add support to rename Service port for Istio

### DIFF
--- a/charts/airflow/CHANGELOG.md
+++ b/charts/airflow/CHANGELOG.md
@@ -7,6 +7,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 
 TBD
 
+## [8.5.4] - 2022-01-10
+
+### Changed
+- add setting for pgbouncer, workers, and web service port names
+  - __pgbouncer setting:__ pgbouncer.service.portName
+  - __workers setting:__ workers.service.portName
+  - __web setting:__ web.service.portName
+
+### Fixed
+- Istio naming convention [issue](https://istio.io/latest/docs/reference/config/analysis/ist0118/) 
+
 ## [8.5.3] - 2022-01-10
 
 > 🟥 __Warning__ 🟥

--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Airflow Helm Chart (User Community) - used to deploy Apache Airflow on Kubernetes
 name: airflow
-version: 8.5.2
+version: 8.6.0
 appVersion: 2.1.2
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://github.com/airflow-helm/charts

--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Airflow Helm Chart (User Community) - used to deploy Apache Airflow on Kubernetes
 name: airflow
-version: 8.6.0
+version: 8.5.4
 appVersion: 2.1.2
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://github.com/airflow-helm/charts

--- a/charts/airflow/templates/webserver/webserver-service.yaml
+++ b/charts/airflow/templates/webserver/webserver-service.yaml
@@ -24,7 +24,7 @@ spec:
     {{- toYaml .Values.web.service.sessionAffinityConfig | nindent 4 }}
   {{- end }}
   ports:
-    - name: web
+    - name: {{ .Values.web.service.portName | default "web" }}
       protocol: TCP
       port: {{ .Values.web.service.externalPort | default 8080 }}
       {{- if and (eq .Values.web.service.type "NodePort") (.Values.web.service.nodePort.http) }}

--- a/charts/airflow/templates/worker/worker-service.yaml
+++ b/charts/airflow/templates/worker/worker-service.yaml
@@ -12,7 +12,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   ports:
-    - name: worker
+    - name: {{ .Values.workers.service.portName | default "workers" }}
       protocol: TCP
       port: 8793
   clusterIP: None

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -671,6 +671,7 @@ web:
     externalPort: 8080
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
+    portName: "web"
     nodePort:
       http: ""
 
@@ -856,6 +857,10 @@ workers:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volume-v1-core
   ##
   extraVolumes: []
+
+  ## sets service configs: workers
+  service:
+    portName: "workers"
 
 ###################################
 ## COMPONENT | Flower
@@ -1520,6 +1525,10 @@ pgbouncer:
     certFile:
       existingSecret: ""
       existingSecretKey: server.crt
+
+  ## sets service configs: pgbouncer
+  service:
+    portName: "pgbouncer"
 
 ###################################
 ## DATABASE | Embedded Postgres


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- allow service port names to be set for pgbouncer, workers, and web Services. This causes [issues](https://istio.io/latest/docs/reference/config/analysis/ist0118/) with istio service mesh when the service ports do not have the protocol. 


## What does your PR do?

parameterize the airflow values.yaml file with {pgbouncer|workers|web}.service.portName settings, and updates the {pgbouncer|workers|webservere}-service.yaml files with the new setting. Also providing sane default in the service files.


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [x] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [x] CHANGELOG.md updated