### PR TITLE
fix: increase default `timeoutSeconds` for probes

### DIFF
--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -532,7 +532,7 @@ scheduler:
     enabled: true
     initialDelaySeconds: 10
     periodSeconds: 30
-    timeoutSeconds: 10
+    timeoutSeconds: 60
     failureThreshold: 5
 
   ## extra pip packages to install in the scheduler Pods
@@ -1438,7 +1438,7 @@ pgbouncer:
     enabled: true
     initialDelaySeconds: 5
     periodSeconds: 30
-    timeoutSeconds: 15
+    timeoutSeconds: 60
     failureThreshold: 3
 
   ## the maximum number of seconds to wait for queries upon pod termination, before force killing


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- fixes https://github.com/airflow-helm/charts/issues/484


## What does your PR do?

This PR changes the default values for `timeoutSeconds` as follows:
- `scheduler.livenessProbe.timeoutSeconds` (old: `10`, new: `60`)
- `pgbouncer.livenessProbe.timeoutSeconds` (old: `15`, new: `60`)


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)