### PR TITLE
feat: add `pgbouncer.authType` value

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1313,9 +1313,16 @@ postgresql:
   ## to use the external db, the embedded one must be disabled
   enabled: false
 
+## for full list of PgBouncer configs, see values.yaml
 pgbouncer:
-  ## for other PgBouncer configs, see the `pgbouncer.*` values
   enabled: true
+
+  ## WARNING: you must set "scram-sha-256" if using Azure PostgreSQL (single server mode)
+  authType: md5
+
+  serverSSL:
+    ## WARNING: you must set "verify-ca" if using Azure PostgreSQL
+    mode: prefer
 
 externalDatabase:
   type: postgres
@@ -2009,6 +2016,7 @@ Parameter | Description | Default
 `pgbouncer.livenessProbe.*` | configs for the pgbouncer Pods' liveness probe | `<see values.yaml>`
 `pgbouncer.startupProbe.*` | configs for the pgbouncer Pods' startup probe | `<see values.yaml>`
 `pgbouncer.terminationGracePeriodSeconds` | the maximum number of seconds to wait for queries upon pod termination, before force killing | `120`
+`pgbouncer.authType` | sets pgbouncer config: `auth_type` | `md5`
 `pgbouncer.maxClientConnections` | sets pgbouncer config: `max_client_conn` | `1000`
 `pgbouncer.poolSize` | sets pgbouncer config: `default_pool_size` | `20`
 `pgbouncer.logDisconnections` | sets pgbouncer config: `log_disconnections` | `0`

--- a/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
+++ b/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
@@ -18,7 +18,7 @@ ignore_startup_parameters = extra_float_digits
 listen_port = 6432
 listen_addr = *
 
-auth_type = md5
+auth_type = {{ .Values.pgbouncer.authType }}
 auth_file = /home/pgbouncer/users.txt
 
 log_disconnections = {{ .Values.pgbouncer.logDisconnections }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1611,6 +1611,10 @@ pgbouncer:
   ##
   terminationGracePeriodSeconds: 120
 
+  ## sets pgbouncer config: `auth_type`
+  ##
+  authType: md5
+
   ## sets pgbouncer config: `max_client_conn`
   ##
   maxClientConnections: 1000


### PR DESCRIPTION
## What issues does your PR fix?

- fixes https://github.com/airflow-helm/charts/issues/412
- resolves https://github.com/airflow-helm/charts/issues/419

## What does your PR do?

- Adds the `pgbouncer.authType` value (default: `md5`) to set the `auth_type` config of PgBouncer.
   - ___NOTE:__ this is important for "Azure PostgreSQL" as the default  `md5` will not work, but `scram-sha-256` will_


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated