### PR TITLE
fix: `airflow.{fernetKey,webserverSecretKey}` overshadow `_CMD` configs

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -611,7 +611,7 @@ You can set the fernet encryption key using the `airflow.fernetKey` value, which
 
 Example values to define the fernet key with `airflow.fernetKey`:
 ```yaml
-airflow:
+aiflow:
   fernetKey: "7T512UXSSmBOkpWimFHIVb8jK6lfmSAvx4mO6Arehnc="
 ```
 
@@ -630,23 +630,27 @@ airflow:
           key: value
 ```
 
-<h3>Option 3 - using the AIRFLOW__CORE__FERNET_KEY_CMD or AIRFLOW__CORE__FERNET_KEY_SECRET environment variables</h3>
+<h3>Option 3 - using `_CMD` or `_SECRET` configs</h3>
 
-You can also set the fernet key by specifying either the `AIRFLOW__CORE__FERNET_KEY_CMD` or `AIRFLOW__CORE__FERNET_KEY_SECRET`
-environment variables. The correct use of these is detailed as part of the Airflow documentation on [Setting Configuration Options](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-config.html) but when using either variable, the `airflow.fernetKey` value must be set to an empty string.
+You can also set the fernet key by specifying either the `AIRFLOW__CORE__FERNET_KEY_CMD` or `AIRFLOW__CORE__FERNET_KEY_SECRET` environment variables.
+Read about how the `_CMD` or `_SECRET` configs work in the ["Setting Configuration Options"](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-config.html) section of the Airflow documentation.
 
-The following example mounts the `airflow-fernet-key` secret to a file which is then read to provide the desired fernet key:
+Example values for using `AIRFLOW__CORE__FERNET_KEY_CMD`:
 
 ```yaml
 airflow:
+  ## WARNING: you must set `fernetKey` to "", otherwise it will take precedence
   fernetKey: ""
-  extraEnv:
-    - name: AIRFLOW__CORE__FERNET_KEY_CMD
-      value: "cat /opt/airflow/fernet-key/value"
+
+  ## NOTE: this is only an example, if your value lives in a Secret, you probably want to use "Option 2" above
+  config:
+    AIRFLOW__CORE__FERNET_KEY_CMD: "cat /opt/airflow/fernet-key/value"
+      
   extraVolumeMounts:
     - name: fernet-key
       mountPath: /opt/airflow/fernet-key
       readOnly: true
+      
   extraVolumes:
     - name: fernet-key
       secret:
@@ -671,7 +675,7 @@ You can set the webserver secret_key using the `airflow.webserverSecretKey` valu
 
 Example values to define the secret_key with `airflow.webserverSecretKey`:
 ```yaml
-airflow:
+aiflow:
   webserverSecretKey: "THIS IS UNSAFE!"
 ```
 
@@ -690,23 +694,27 @@ airflow:
           key: value
 ```
 
-<h3>Option 3 - using the AIRFLOW__WEBSERVER__SECRET_KEY_CMD or AIRFLOW__WEBSERVER__SECRET_KEY_SECRET environment variables</h3>
+<h3>Option 3 - using `_CMD` or `_SECRET` configs</h3>
 
-You can also set the webserver secret key by specifying either the `AIRFLOW__WEBSERVER__SECRET_KEY_CMD` or `AIRFLOW__WEBSERVER__SECRET_KEY_SECRET`
-environment variables. The correct use of these is detailed as part of the Airflow documentation on [Setting Configuration Options](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-config.html) but when using either variable, the `airflow.webserverSecretKey` value must be set to an empty string.
+You can also set the webserver secret key by specifying either the `AIRFLOW__WEBSERVER__SECRET_KEY_CMD` or `AIRFLOW__WEBSERVER__SECRET_KEY_SECRET` environment variables. 
+Read about how the `_CMD` or `_SECRET` configs work in the ["Setting Configuration Options"](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-config.html) section of the Airflow documentation.
 
-The following example mounts the `airflow-webserver-secret-key` secret to a file which is then read to provide the desired webserver secret key:
+Example values for using `AIRFLOW__WEBSERVER__SECRET_KEY_CMD`:
 
 ```yaml
 airflow:
-  fernetKey: ""
-  extraEnv:
-    - name: AIRFLOW__WEBSERVER__SECRET_KEY_CMD
-      value: "cat /opt/airflow/webserver-secret-key/value"
+  ## WARNING: you must set `webserverSecretKey` to "", otherwise it will take precedence
+  webserverSecretKey: ""
+
+  ## NOTE: this is only an example, if your value lives in a Secret, you probably want to use "Option 2" above
+  config:
+    AIRFLOW__WEBSERVER__SECRET_KEY_CMD: "cat /opt/airflow/webserver-secret-key/value"
+      
   extraVolumeMounts:
     - name: webserver-secret-key
       mountPath: /opt/airflow/webserver-secret-key
       readOnly: true
+      
   extraVolumes:
     - name: webserver-secret-key
       secret:
@@ -727,7 +735,7 @@ You can use the `airflow.connections` value to create airflow [Connections](http
 
 Example values to create connections called `my_aws`, `my_gcp`, `my_postgres`, and `my_ssh`:
 ```yaml
-airflow:
+airflow: 
   connections:
     ## see docs: https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html
     - id: my_aws
@@ -780,7 +788,7 @@ You can use `airflow.connectionsTemplates` to extract string templates from keys
 
 Example values to use templates from `Secret/my-secret` and `ConfigMap/my-configmap` in parts of the `my_aws` connection:
 ```yaml
-airflow:
+airflow: 
   connections:
     - id: my_aws
       type: aws

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -630,6 +630,29 @@ airflow:
           key: value
 ```
 
+<h3>Option 3 - using the AIRFLOW__CORE__FERNET_KEY_CMD or AIRFLOW__CORE__FERNET_KEY_SECRET environment variables</h3>
+
+You can also set the fernet key by specifying either the `AIRFLOW__CORE__FERNET_KEY_CMD` or `AIRFLOW__CORE__FERNET_KEY_SECRET`
+environment variables. The correct use of these is detailed as part of the Airflow documentation on [Setting Configuration Options](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-config.html) but when using either variable, the `airflow.fernetKey` value must be set to an empty string.
+
+The following example mounts the `airflow-fernet-key` secret to a file which is then read to provide the desired fernet key:
+
+```yaml
+airflow:
+  fernetKey: ""
+  extraEnv:
+    - name: AIRFLOW__CORE__FERNET_KEY_CMD
+      value: "cat /opt/airflow/fernet-key/value"
+  extraVolumeMounts:
+    - name: fernet-key
+      mountPath: /opt/airflow/fernet-key
+      readOnly: true
+  extraVolumes:
+    - name: fernet-key
+      secret:
+        secretName: airflow-fernet-key
+```
+
 <hr>
 </details>
 
@@ -665,6 +688,29 @@ airflow:
         secretKeyRef:
           name: airflow-webserver-secret-key
           key: value
+```
+
+<h3>Option 3 - using the AIRFLOW__WEBSERVER__SECRET_KEY_CMD or AIRFLOW__WEBSERVER__SECRET_KEY_SECRET environment variables</h3>
+
+You can also set the webserver secret key by specifying either the `AIRFLOW__WEBSERVER__SECRET_KEY_CMD` or `AIRFLOW__WEBSERVER__SECRET_KEY_SECRET`
+environment variables. The correct use of these is detailed as part of the Airflow documentation on [Setting Configuration Options](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-config.html) but when using either variable, the `airflow.webserverSecretKey` value must be set to an empty string.
+
+The following example mounts the `airflow-webserver-secret-key` secret to a file which is then read to provide the desired webserver secret key:
+
+```yaml
+airflow:
+  fernetKey: ""
+  extraEnv:
+    - name: AIRFLOW__WEBSERVER__SECRET_KEY_CMD
+      value: "cat /opt/airflow/webserver-secret-key/value"
+  extraVolumeMounts:
+    - name: webserver-secret-key
+      mountPath: /opt/airflow/webserver-secret-key
+      readOnly: true
+  extraVolumes:
+    - name: webserver-secret-key
+      secret:
+        secretName: airflow-webserver-secret-key
 ```
 
 <hr>

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -611,7 +611,7 @@ You can set the fernet encryption key using the `airflow.fernetKey` value, which
 
 Example values to define the fernet key with `airflow.fernetKey`:
 ```yaml
-aiflow:
+airflow:
   fernetKey: "7T512UXSSmBOkpWimFHIVb8jK6lfmSAvx4mO6Arehnc="
 ```
 
@@ -671,7 +671,7 @@ You can set the webserver secret_key using the `airflow.webserverSecretKey` valu
 
 Example values to define the secret_key with `airflow.webserverSecretKey`:
 ```yaml
-aiflow:
+airflow:
   webserverSecretKey: "THIS IS UNSAFE!"
 ```
 
@@ -727,7 +727,7 @@ You can use the `airflow.connections` value to create airflow [Connections](http
 
 Example values to create connections called `my_aws`, `my_gcp`, `my_postgres`, and `my_ssh`:
 ```yaml
-airflow: 
+airflow:
   connections:
     ## see docs: https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html
     - id: my_aws
@@ -780,7 +780,7 @@ You can use `airflow.connectionsTemplates` to extract string templates from keys
 
 Example values to use templates from `Secret/my-secret` and `ConfigMap/my-configmap` in parts of the `my_aws` connection:
 ```yaml
-airflow: 
+airflow:
   connections:
     - id: my_aws
       type: aws

--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -95,9 +95,13 @@ data:
   ## ================
   AIRFLOW__CORE__DAGS_FOLDER: {{ include "airflow.dags.path" . | b64enc | quote }}
   AIRFLOW__CORE__EXECUTOR: {{ .Values.airflow.executor | b64enc | quote }}
+  {{- if .Values.airflow.fernetKey }}
   AIRFLOW__CORE__FERNET_KEY: {{ .Values.airflow.fernetKey | b64enc | quote }}
+  {{- end }}
   AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD: {{ `bash -c 'eval "$DATABASE_SQLALCHEMY_CMD"'` | b64enc | quote }}
+  {{- if .Values.airflow.webserverSecretKey }}
   AIRFLOW__WEBSERVER__SECRET_KEY: {{ .Values.airflow.webserverSecretKey | b64enc | quote }}
+  {{- end }}
   AIRFLOW__WEBSERVER__WEB_SERVER_PORT: {{ "8080" | b64enc | quote }}
   AIRFLOW__CELERY__FLOWER_PORT: {{ "5555" | b64enc | quote }}
 

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -28,12 +28,18 @@ airflow:
   ## - use this command to generate your own fernet key:
   ##   python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)"
   ##
+  ## if setting the AIRFLOW__CORE__FERNET_KEY_CMD or AIRFLOW__CORE__FERNET_KEY_SECRET environment variables
+  ## set the value to an empty string to avoid the setting of the AIRFLOW__CORE__FERNET_KEY value before setting the 
+  ## desired environment variable.
   fernetKey: "7T512UXSSmBOkpWimFHIVb8jK6lfmSAvx4mO6Arehnc="
 
   ## the secret_key for flask (sets `AIRFLOW__WEBSERVER__SECRET_KEY`)
   ## - [WARNING] you must change this value to ensure the security of your airflow
   ## - set `AIRFLOW__WEBSERVER__SECRET_KEY` with `airflow.extraEnv` from a Secret to avoid storing this in your values
   ##
+  ## if setting the AIRFLOW__WEBSERVER__SECRET_KEY_CMD or AIRFLOW__WEBSERVER__SECRET_KEY_SECRET environment variables
+  ## set the value to an empty string to avoid the setting of the AIRFLOW__WEBSERVER__SECRET_KEY value before setting the 
+  ## desired environment variable.
   webserverSecretKey: "THIS IS UNSAFE!"
 
   ## environment variables for airflow configs

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -28,18 +28,12 @@ airflow:
   ## - use this command to generate your own fernet key:
   ##   python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)"
   ##
-  ## if setting the AIRFLOW__CORE__FERNET_KEY_CMD or AIRFLOW__CORE__FERNET_KEY_SECRET environment variables
-  ## set the value to an empty string to avoid the setting of the AIRFLOW__CORE__FERNET_KEY value before setting the
-  ## desired environment variable.
   fernetKey: "7T512UXSSmBOkpWimFHIVb8jK6lfmSAvx4mO6Arehnc="
 
   ## the secret_key for flask (sets `AIRFLOW__WEBSERVER__SECRET_KEY`)
   ## - [WARNING] you must change this value to ensure the security of your airflow
   ## - set `AIRFLOW__WEBSERVER__SECRET_KEY` with `airflow.extraEnv` from a Secret to avoid storing this in your values
   ##
-  ## if setting the AIRFLOW__WEBSERVER__SECRET_KEY_CMD or AIRFLOW__WEBSERVER__SECRET_KEY_SECRET environment variables
-  ## set the value to an empty string to avoid the setting of the AIRFLOW__WEBSERVER__SECRET_KEY value before setting the
-  ## desired environment variable.
   webserverSecretKey: "THIS IS UNSAFE!"
 
   ## environment variables for airflow configs

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -29,7 +29,7 @@ airflow:
   ##   python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)"
   ##
   ## if setting the AIRFLOW__CORE__FERNET_KEY_CMD or AIRFLOW__CORE__FERNET_KEY_SECRET environment variables
-  ## set the value to an empty string to avoid the setting of the AIRFLOW__CORE__FERNET_KEY value before setting the 
+  ## set the value to an empty string to avoid the setting of the AIRFLOW__CORE__FERNET_KEY value before setting the
   ## desired environment variable.
   fernetKey: "7T512UXSSmBOkpWimFHIVb8jK6lfmSAvx4mO6Arehnc="
 
@@ -38,7 +38,7 @@ airflow:
   ## - set `AIRFLOW__WEBSERVER__SECRET_KEY` with `airflow.extraEnv` from a Secret to avoid storing this in your values
   ##
   ## if setting the AIRFLOW__WEBSERVER__SECRET_KEY_CMD or AIRFLOW__WEBSERVER__SECRET_KEY_SECRET environment variables
-  ## set the value to an empty string to avoid the setting of the AIRFLOW__WEBSERVER__SECRET_KEY value before setting the 
+  ## set the value to an empty string to avoid the setting of the AIRFLOW__WEBSERVER__SECRET_KEY value before setting the
   ## desired environment variable.
   webserverSecretKey: "THIS IS UNSAFE!"
 


### PR DESCRIPTION
## What issues does your PR fix?

- fixes #506 


## What does your PR do?

- Only set `AIRFLOW__CORE__FERNET_KEY` and `AIRFLOW__WEBSERVER__SECRET_KEY` when the values of `airflow.fernetKey` and `airflow.webserverSecretKey` are non-empty. 
   - Allows the use of the `_CMD` and `_SECRET` variables, which are currently overshadowed by their non-suffixed versions.

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated