### PR TITLE
ci: reusable workflows PoC

### DIFF
--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -1,0 +1,43 @@
+name: "Test setup"
+
+on:
+  workflow_call:
+    inputs:
+      platforms:
+        required: true
+        type: string
+    secrets: {}
+
+jobs:
+  setup-container-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Install Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Generate Image Tags/Labels
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            airflowhelm/charts
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=pr
+
+      - name: Build Image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./images/pgbouncer
+          push: false
+          platforms: ${{ inputs.platforms }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/images-pgbouncer--run-tests.yaml
+++ b/.github/workflows/images-pgbouncer--run-tests.yaml
@@ -9,35 +9,7 @@ on:
 
 jobs:
   build-container-image:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Install QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Install Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Generate Image Tags/Labels
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            airflowhelm/charts
-            ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=pr
-
-      - name: Build Image
-        uses: docker/build-push-action@v2
-        with:
-          context: ./images/pgbouncer
-          push: false
-          platforms: |
-            linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+    uses: ./.github/workflows/build-container-image.yaml
+    with:
+      platforms: |
+        linux/amd64


### PR DESCRIPTION
This is a simple proof of concept of reusable workflows
https://docs.github.com/en/actions/using-workflows/reusing-workflows

It paramaterises the build-container-image job in
images-pgbouncer--run-tests.yaml, illustrating how to define and call a
reusable workflow and pass parameters to it.

<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## Checklist

### For all Pull Requests

- [ ] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [ ] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [ ] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated