### PR TITLE
feat: add liveness and readiness probes to workers

### DIFF
--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -162,7 +162,39 @@ spec:
             {{- else }}
             - "exec airflow celery worker"
             {{- end }}
-          {{- if $volumeMounts }}
+          {{- if .Values.workers.livenessProbe.enabled }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.workers.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workers.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.workers.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.workers.livenessProbe.failureThreshold }}
+            exec:
+              command:
+              - celery
+              - --app
+              - airflow.executors.celery_executor.app
+              - inspect
+              - ping
+              - -d
+              - celery@${HOSTNAME}
+          {{- end }}
+          {{- if .Values.workers.readinessProbe.enabled }}
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.workers.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workers.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.workers.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.workers.readinessProbe.failureThreshold }}
+            exec:
+              command:
+              - celery
+              - --app
+              - airflow.executors.celery_executor.app
+              - inspect
+              - ping
+              - -d
+              - celery@${HOSTNAME}
+          {{- end }}
+         {{- if $volumeMounts }}
           volumeMounts:
             {{- $volumeMounts | indent 12 }}
           {{- end }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -791,6 +791,25 @@ workers:
     ##
     minAvailable: ""
 
+  ## configs for the worker Pods' readinessProbe probe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 120
+    periodSeconds: 120
+    timeoutSeconds: 20
+    failureThreshold: 5
+
+  ## configs for the worker Pods' liveness probe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 15
+    failureThreshold: 5
+
+
   ## configs for the HorizontalPodAutoscaler of the worker Pods
   ## - [WARNING] if using git-sync, ensure `dags.gitSync.resources` is set
   ##


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- Worker can stop to work and no liveness probes will restart it.

## What does your PR do?

Add liveness and readiness probes.

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [ ] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated