### PR TITLE
feat: fully support helm templating in `extraManifests`

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1404,18 +1404,67 @@ A [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/bl
 <summary>Expand</summary>
 <hr>
 
-You can use the `extraManifests.[]` value to add custom Kubernetes manifests to the chart.
+You may use the `extraManifests` value to specify a list of extra Kubernetes manifests that will be deployed alongside the chart.
 
-Example values to add a `BackendConfig` resource (for GKE):
+> 🟦 __Tip__ 🟦 
+> 
+> [Helm templates](https://helm.sh/docs/chart_template_guide/functions_and_pipelines/) within these strings will be rendered
+
+Example values to create a `Secret` for database credentials: _(__WARNING:__ store custom values securely if used)_
 ```yaml
 extraManifests:
-  - apiVersion: cloud.google.com/v1beta1
-    kind: BackendConfig
+  - |
+    apiVersion: v1
+    kind: Secret
     metadata:
-      name: "{{ .Release.Name }}-test"
+      name: airflow-postgres-credentials
+    data:
+      postgresql-password: {{ `password1` | b64enc | quote }}
+```
+
+Example values to create a `Deployment` for a [busybox](https://busybox.net/) container:
+```yaml
+extraManifests:
+  - |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: {{ include "airflow.fullname" . }}-busybox
+      labels:
+        app: {{ include "airflow.labels.app" . }}
+        component: busybox
+        chart: {{ include "airflow.labels.chart" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
     spec:
-      securityPolicy:
-        name: "gcp-cloud-armor-policy-test"
+      replicas: 1
+      selector:
+        matchLabels:
+          app: {{ include "airflow.labels.app" . }}
+          component: busybox
+          release: {{ .Release.Name }}
+      template:
+        metadata:
+          labels:
+            app: {{ include "airflow.labels.app" . }}
+            component: busybox
+            release: {{ .Release.Name }}
+        spec:
+          containers:
+            - name: busybox
+              image: busybox:1.35
+              command:
+                - "/bin/sh"
+                - "-c"
+              args:
+                - |
+                  ## to break the infinite loop when we receive SIGTERM
+                  trap "exit 0" SIGTERM;
+                  ## keep the container running (so people can `kubectl exec -it` into it)
+                  while true; do
+                    echo "I am alive...";
+                    sleep 30;
+                  done
 ```
 
 <hr>
@@ -1661,7 +1710,7 @@ Parameter | Description | Default
 
 Parameter | Description | Default
 --- | --- | ---
-`extraManifests` | extra Kubernetes manifests to include alongside this chart | `[]`
+`extraManifests` | a list of extra Kubernetes manifests that will be deployed alongside the chart | `[]`
 
 <hr>
 </details>

--- a/charts/airflow/templates/extra-manifests.yaml
+++ b/charts/airflow/templates/extra-manifests.yaml
@@ -1,4 +1,9 @@
-{{- range .Values.extraManifests }}
+{{- range $manifest := .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{- if typeIs "string" $manifest }}
+{{ tpl $manifest $ }}
+{{- else }}
+{{- /* support non-string manifests for backwards compatibility with previous chart versions */ -}}
+{{ tpl (toYaml $manifest) $ }}
+{{- end }}
 {{- end }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1335,18 +1335,58 @@ serviceAccount:
 ###################################
 ## CONFIG | Kubernetes Extra Manifests
 ###################################
-## extra Kubernetes manifests to include alongside this chart
-## - this can be used to include ANY Kubernetes YAML resource
+## a list of extra Kubernetes manifests that will be deployed alongside the chart
+## - helm templates within these strings will be rendered
 ##
 ## ____ EXAMPLE _______________
 ##   extraManifests:
-##    - apiVersion: cloud.google.com/v1beta1
-##      kind: BackendConfig
-##      metadata:
-##        name: "{{ .Release.Name }}-test"
-##      spec:
-##        securityPolicy:
-##          name: "gcp-cloud-armor-policy-test"
+##     - |
+##       apiVersion: v1
+##       kind: Secret
+##       metadata:
+##         name: airflow-postgres
+##       data:
+##         postgresql-password: {{ `password1` | b64enc | quote }}
+##     - |
+##       apiVersion: apps/v1
+##       kind: Deployment
+##       metadata:
+##         name: {{ include "airflow.fullname" . }}-busybox
+##         labels:
+##           app: {{ include "airflow.labels.app" . }}
+##           component: busybox
+##           chart: {{ include "airflow.labels.chart" . }}
+##           release: {{ .Release.Name }}
+##           heritage: {{ .Release.Service }}
+##       spec:
+##         replicas: 1
+##         selector:
+##           matchLabels:
+##             app: {{ include "airflow.labels.app" . }}
+##             component: busybox
+##             release: {{ .Release.Name }}
+##         template:
+##           metadata:
+##             labels:
+##               app: {{ include "airflow.labels.app" . }}
+##               component: busybox
+##               release: {{ .Release.Name }}
+##           spec:
+##             containers:
+##               - name: busybox
+##                 image: busybox:1.35
+##                 command:
+##                   - "/bin/sh"
+##                   - "-c"
+##                 args:
+##                   - |
+##                     ## to break the infinite loop when we receive SIGTERM
+##                     trap "exit 0" SIGTERM;
+##                     ## keep the container running (so people can `kubectl exec -it` into it)
+##                     while true; do
+##                       echo "I am alive...";
+##                       sleep 30;
+##                     done
 ##
 extraManifests: []
 


### PR DESCRIPTION
## What issues does your PR fix?

- resolves https://github.com/airflow-helm/charts/issues/522

## What does your PR do?

- Allows for elements of `extraManifests` to be strings (not objects), which enables full support for Helm templating.
- Updates the docstring/readme with examples of string-based `extraManifests` that use complex Helm templating.
- Existing users who specified `extraManifests` as a list of objects (not strings) should not be impacted by this change.
- We intend for new users to specify `extraManifests` as a list of strings, so they can make full use of Helm templating.

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated