### PR TITLE
feat: add `ingressClassName` value to ingress

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1235,7 +1235,7 @@ Consider the situation where you already have something hosted at the root of yo
 - http://example.com/airflow/
 - http://example.com/airflow/flower
 
-In this example, would set these values:
+In this example, you would set these values, assuming you have an Ingress Controller with an IngressClass named "nginx" deployed:
 ```yaml
 airflow:
   config: 
@@ -1250,17 +1250,19 @@ ingress:
   
   ## airflow webserver ingress configs
   web:
-    annotations:
-      kubernetes.io/ingress.class: nginx
+    annotations: {}
     host: "example.com"
     path: "/airflow"
+    ## WARNING: requires Kubernetes 1.18 or later, use "kubernetes.io/ingress.class" annotation for older versions
+    ingressClassName: "nginx"
     
   ## flower ingress configs
   flower:
-    annotations:
-      kubernetes.io/ingress.class: nginx
+    annotations: {}
     host: "example.com"
     path: "/airflow/flower"
+    ## WARNING: requires Kubernetes 1.18 or later, use "kubernetes.io/ingress.class" annotation for older versions
+    ingressClassName: "nginx"
 ```
 
 We expose the `ingress.web.precedingPaths` and `ingress.web.succeedingPaths` values, which are __before__ and __after__ the default path respectively.

--- a/charts/airflow/templates/flower/flower-ingress-v1beta1.yaml
+++ b/charts/airflow/templates/flower/flower-ingress-v1beta1.yaml
@@ -25,6 +25,9 @@ spec:
       secretName: {{ .Values.ingress.flower.tls.secretName }}
       {{- end }}
   {{- end }}
+  {{- if .Values.ingress.flower.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.flower.ingressClassName }}
+  {{- end }}  
   rules:
     - host: {{ .Values.ingress.flower.host }}
       http:

--- a/charts/airflow/templates/flower/flower-ingress.yaml
+++ b/charts/airflow/templates/flower/flower-ingress.yaml
@@ -25,6 +25,9 @@ spec:
       secretName: {{ .Values.ingress.flower.tls.secretName }}
       {{- end }}
   {{- end }}
+  {{- if .Values.ingress.flower.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.flower.ingressClassName }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.flower.host }}
       http:

--- a/charts/airflow/templates/webserver/webserver-ingress-v1beta1.yaml
+++ b/charts/airflow/templates/webserver/webserver-ingress-v1beta1.yaml
@@ -25,6 +25,9 @@ spec:
       secretName: {{ .Values.ingress.web.tls.secretName }}
       {{- end }}
   {{- end }}
+  {{- if .Values.ingress.web.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.web.ingressClassName }}
+  {{- end }}  
   rules:
     - host: {{ .Values.ingress.web.host }}
       http:

--- a/charts/airflow/templates/webserver/webserver-ingress.yaml
+++ b/charts/airflow/templates/webserver/webserver-ingress.yaml
@@ -25,6 +25,9 @@ spec:
       secretName: {{ .Values.ingress.web.tls.secretName }}
       {{- end }}
   {{- end }}
+  {{- if .Values.ingress.web.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.web.ingressClassName }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.web.host }}
       http:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1203,6 +1203,11 @@ ingress:
     ##
     host: ""
 
+    ## the Ingress Class for the web Ingress
+    ## - [WARNING] requires Kubernetes 1.18 or later, use "kubernetes.io/ingress.class" annotation for older versions
+    ##
+    ingressClassName: ""
+
     ## configs for web Ingress TLS
     ##
     tls:
@@ -1257,6 +1262,11 @@ ingress:
     ## the hostname for the flower Ingress
     ##
     host: ""
+
+    ## the Ingress Class for the flower Ingress
+    ## - [WARNING] requires Kubernetes 1.18 or later, use "kubernetes.io/ingress.class" annotation for older versions
+    ##
+    ingressClassName: ""
 
     ## configs for flower Ingress TLS
     ##


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- resolves #427
- fixes #425 
- replaces #426
- replaces #524


## What does your PR do?

- Adds the following values to allow setting `ingressClassName` on the Ingress resources:
   - `ingress.web.ingressClassName`
   - `ingress.flower.ingressClassName`


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated

---

_P.S.: Sorry, I accidentally closed the original pull request #524_.