### PR TITLE
fix: PG_ADVISORY_LOCK are not released in pgbouncer

### DIFF
--- a/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
+++ b/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
@@ -24,6 +24,10 @@ auth_file = /home/pgbouncer/users.txt
 log_disconnections = {{ .Values.pgbouncer.logDisconnections }}
 log_connections = {{ .Values.pgbouncer.logConnections }}
 
+# locks will never be released when `pool_mode=transaction` (airflow initdb/upgradedb scripts create locks)
+server_reset_query = SELECT pg_advisory_unlock_all()
+server_reset_query_always = 1
+
 ## CLIENT TLS SETTINGS ##
 client_tls_sslmode = {{ .Values.pgbouncer.clientSSL.mode }}
 client_tls_ciphers = {{ .Values.pgbouncer.clientSSL.ciphers }}


### PR DESCRIPTION
## What issues does your PR fix?

Currently, the `db-migrations` Deployment will hang forever after printing `WARNING - there are unapplied db migrations, triggering apply... ` when attempting to upgrade airflow from `2.2.X` to something newer.

When this happens, the only solution is to restart the PgBouncer Pod.

## What does your PR do?

As of Airflow 2.2.0, the [`upgradedb()`](https://github.com/apache/airflow/blob/2.2.0/airflow/utils/db.py#L822) command now [creates a `PG_ADVISORY_LOCK`](https://github.com/apache/airflow/blob/2.2.0/airflow/utils/session.py#L82).

We run PgBouncer in [`pool_mode = transaction`](https://github.com/airflow-helm/charts/blob/df99a33e3278de9f6935e747e8317794966ed979/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl#L13), in this mode, locks will never be released, because the "lock" and "unlock" statements are necessarily in separate transactions, and there is no guarantee that these transactions will be run on the same session by PgBouncer.

To solve this, this PR uses the [`server_reset_query` and `server_reset_query_always`](https://www.pgbouncer.org/config.html#connection-sanity-checks-timeouts) configs of PgBouncer, to run a `SELECT pg_advisory_unlock_all()` query after each transaction. This ensures any locks that were created are immediately removed. In our case, this is fine, because only [one instance of `db-migrations` will run at a time](https://github.com/airflow-helm/charts/blob/df99a33e3278de9f6935e747e8317794966ed979/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml#L24-L27) (in most situations), so the locks arent strictly nesseesary.

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated