### PR TITLE
fix: allow ingress `servicePort` to be string or number

### DIFF
--- a/charts/airflow/templates/flower/flower-ingress.yaml
+++ b/charts/airflow/templates/flower/flower-ingress.yaml
@@ -36,7 +36,11 @@ spec:
               service:
                 name: {{ .serviceName }}
                 port:
+                  {{- if kindIs "string" .servicePort }}
+                  name: {{ .servicePort }}
+                  {{- else }}
                   number: {{ .servicePort }}
+                  {{- end }}
           {{- end }}
           - path: {{ .Values.ingress.flower.path }}
             pathType: ImplementationSpecific
@@ -52,6 +56,10 @@ spec:
               service:
                 name: {{ .serviceName }}
                 port:
+                  {{- if kindIs "string" .servicePort }}
+                  name: {{ .servicePort }}
+                  {{- else }}
                   number: {{ .servicePort }}
+                  {{- end }}
           {{- end }}
 {{- end }}

--- a/charts/airflow/templates/webserver/webserver-ingress.yaml
+++ b/charts/airflow/templates/webserver/webserver-ingress.yaml
@@ -36,7 +36,11 @@ spec:
               service:
                 name: {{ .serviceName }}
                 port:
+                  {{- if kindIs "string" .servicePort }}
+                  name: {{ .servicePort }}
+                  {{- else }}
                   number: {{ .servicePort }}
+                  {{- end }}
           {{- end }}
           - path: {{ .Values.ingress.web.path }}
             pathType: ImplementationSpecific
@@ -52,7 +56,11 @@ spec:
               service:
                 name: {{ .serviceName }}
                 port:
+                  {{- if kindIs "string" .servicePort }}
+                  name: {{ .servicePort }}
+                  {{- else }}
                   number: {{ .servicePort }}
+                  {{- end }}
           {{- end }}
 
 {{- end }}


### PR DESCRIPTION
## What issues does your PR fix?

- fixes https://github.com/airflow-helm/charts/issues/477


## What does your PR do?

When we migrated to the `networking.k8s.io/v1` version of Ingress, we incorrectly assumed that `ingress.web.precedingPaths[].servicePort` would always be a number, when previously it could be a port-name also.

This PR, ensure that we place the `servicePort` into the correct Ingress field, depending on if it is a string or a number.

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated