### PR TITLE
fix: only set `CONNECTION_CHECK_MAX_COUNT` once

### DIFF
--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -53,16 +53,12 @@ spec:
       envFrom:
         {{- include "airflow.envFrom" . | indent 8 }}
       env:
-        {{- if not .Values.airflow.legacyCommands }}
-        ## enable the `/entrypoint` db connection check
-        - name: CONNECTION_CHECK_MAX_COUNT
-          value: "20"
-        {{- end }}
         ## KubernetesExecutor Pods use LocalExecutor internally
         - name: AIRFLOW__CORE__EXECUTOR
           value: LocalExecutor
-        {{- /* this has user-defined variables, so must be included BELOW (so the ABOVE `env` take precedence) */ -}}
-        {{- include "airflow.env" . | indent 8 }}
+        {{- /* NOTE: the FIRST definition of an `env` takes precedence (so we include user-defined `env` LAST) */ -}}
+        {{- /* NOTE: we set `CONNECTION_CHECK_MAX_COUNT=20` to enable airflow's `/entrypoint` db connection check */ -}}
+        {{- include "airflow.env" (dict "Release" .Release "Values" .Values "CONNECTION_CHECK_MAX_COUNT" "20")  | indent 8 }}
       ports: []
       command: []
       args: []

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -408,6 +408,7 @@ The list of `envFrom` for web/scheduler/worker/flower Pods
 
 {{/*
 The list of `env` for web/scheduler/worker/flower Pods
+EXAMPLE USAGE: {{ include "airflow.env" (dict "Release" .Release "Values" .Values "CONNECTION_CHECK_MAX_COUNT" "0") }}
 */}}
 {{- define "airflow.env" }}
 {{- /* postgres environment variables */ -}}
@@ -469,7 +470,11 @@ The list of `env` for web/scheduler/worker/flower Pods
 {{- /* disable the `/entrypoint` db connection check */ -}}
 {{- if not .Values.airflow.legacyCommands }}
 - name: CONNECTION_CHECK_MAX_COUNT
+  {{- if .CONNECTION_CHECK_MAX_COUNT }}
+  value: {{ .CONNECTION_CHECK_MAX_COUNT | quote }}
+  {{- else }}
   value: "0"
+  {{- end }}
 {{- end }}
 
 {{- /* set AIRFLOW__CELERY__FLOWER_BASIC_AUTH */ -}}


### PR DESCRIPTION
## What issues does your PR fix?

- fixes #532

The double-setting of `CONNECTION_CHECK_MAX_COUNT` was preventing the airflow scheduler from adopting pods due to k8s thinking the env var value was changing when the pod was being patched:

```
[2022-02-24 22:24:48,385] {kubernetes_executor.py:665} INFO - attempting to adopt pod podname.69b7727977014e948bc0b31cb2946803
[2022-02-24 22:24:48,399] {kubernetes_executor.py:683} INFO - Failed to adopt pod podname.69b7727977014e948bc0b31cb2946803. Reason: (422)
Reason: Unprocessable Entity
... is invalid: spec: Forbidden: pod updates may not change fields other than `spec.containers[*].image`, `spec.initContainers[*].image`, `spec.activeDeadlineSeconds` or `spec.tolerations`
```

The change in question that is preventing the patch request:
```
Name:      \"CONNECTION_CHECK_MAX_COUNT\",
Value:     \"0\",
Value:     \"20\",
ValueFrom: nil
```


## What does your PR do?

- Ensures that the kubernetesExecutor pod_template only has one `CONNECTION_CHECK_MAX_COUNT` in its `env`:
    - ___NOTE:__ the default `CONNECTION_CHECK_MAX_COUNT` is still `20` (when `airflow.legacyCommands=false`)_

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated