### PR TITLE
feat: add `airflow.kubernetesPodTemplate.podLabels` value

### DIFF
--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -15,6 +15,10 @@ metadata:
   annotations:
     {{- toYaml .Values.airflow.kubernetesPodTemplate.podAnnotations | nindent 4 }}
   {{- end }}
+  {{- if .Values.airflow.kubernetesPodTemplate.podLabels }}
+  labels:
+    {{- toYaml .Values.airflow.kubernetesPodTemplate.podLabels | nindent 4 }}
+  {{- end }}
 spec:
   restartPolicy: Never
   {{- if .Values.airflow.image.pullSecret }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -299,7 +299,12 @@ airflow:
     ##
     tolerations: []
 
+    ## labels for the Pod template
+    ##
+    podLabels: {}
+
     ## annotations for the Pod template
+    ##
     podAnnotations: {}
 
     ## the security context for the Pod template


### PR DESCRIPTION
## What issues does your PR fix?

Sometimes it is necessary to set Pod labels on the KubernetesExecutor pod_template.

For example, when running a cluster with an older version of Istio, [there is a bug which can result in Istio applying a label that is longer than the 63 character limit](https://github.com/istio/istio/issues/25157), users work around this issue by applying an `app.kubernetes.io/name` or `app` label to the Pod.

The PR allows you to define the labels in the `kubernetesPodTemplate`, something that was previously only possible by adding in the whole of the pod template via the `airflow.kubernetesPodTemplate.stringOverride` variable.

## What does your PR do?

- Adds the `airflow.kubernetesPodTemplate.podLabels` value to set Pod labels on the KubernetesExecutor pod_template.

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated