### PR TITLE
feat: allow templates in userSecret/passwordSecret/host/etc values

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1155,6 +1155,33 @@ externalRedis:
 <hr>
 </details>
 
+### How to use with [postgres-operator](https://opensource.zalando.com/postgres-operator/)?
+<details>
+<summary>Expand</summary>
+<hr>
+
+Example values for a PostgreSQL instance managed by [postgres-operator](https://opensource.zalando.com/postgres-operator/):
+```yaml
+postgresql:
+  enabled: false
+
+externalDatabase:
+  type: postgres
+  host: postgres-cluster.default
+  port: 5432
+  database: airflow
+  user: ""
+  userSecret: "airflow-airflow-owner-user.postgres-cluster.credentials.postgresql.acid.zalan.do"
+  userSecretKey: "username"
+  passwordSecret: "airflow-airflow-owner-user.postgres-cluster.credentials.postgresql.acid.zalan.do"
+  passwordSecretKey: "password"
+
+  # use this for any extra connection-string settings, e.g. ?useSSL=false
+  properties: ""
+```
+
+<hr>
+</details>
 ## FAQ - Kubernetes
 
 > __Frequently asked questions related to kubernetes configs__

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -406,10 +406,6 @@ The list of `envFrom` for web/scheduler/worker/flower Pods
     name: {{ include "airflow.fullname" . }}-config-envs
 {{- end }}
 
-{{- define "magda.var_dump" -}}
-{{- . | mustToPrettyJson | printf "\nThe JSON output of the dumped var is: \n%s" }}
-{{- end -}}
-
 {{/*
 The list of `env` for web/scheduler/worker/flower Pods
 */}}

--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -25,7 +25,7 @@ data:
   DATABASE_HOST: {{ printf "%s.%s.svc.cluster.local" (include "airflow.postgresql.fullname" .) (.Release.Namespace) | b64enc | quote }}
   DATABASE_PORT: {{ "5432" | b64enc | quote }}
   {{- else }}
-  DATABASE_HOST: {{ .Values.externalDatabase.host | b64enc | quote }}
+  DATABASE_HOST: {{ tpl .Values.externalDatabase.host . | b64enc | quote }}
   DATABASE_PORT: {{ .Values.externalDatabase.port | toString | b64enc | quote }}
   {{- end }}
 
@@ -34,7 +34,11 @@ data:
   DATABASE_USER: {{ .Values.postgresql.postgresqlUsername | b64enc | quote }}
   DATABASE_DB: {{ .Values.postgresql.postgresqlDatabase | b64enc | quote }}
   {{- else }}
+  {{- if and (.Values.externalDatabase.userSecret) (not .Values.externalDatabase.user) }}
+  ## defined in "airflow.env" in pods.tpl
+  {{- else }}
   DATABASE_USER: {{ .Values.externalDatabase.user | b64enc | quote }}
+  {{- end }}
   DATABASE_DB: {{ .Values.externalDatabase.database | b64enc | quote }}
   DATABASE_PROPERTIES: {{ .Values.externalDatabase.properties | b64enc | quote }}
   {{- end }}

--- a/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
@@ -83,7 +83,7 @@ spec:
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: db-migrations
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/db-migrations/db-migrations-job.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-job.yaml
@@ -77,7 +77,7 @@ spec:
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: db-migrations
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -90,8 +90,8 @@ spec:
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: airflow-flower
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
+++ b/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
@@ -6,7 +6,7 @@ Define the content of the `pgbouncer.ini` config file.
 {{- if .Values.postgresql.enabled }}
 * = host={{ printf "%s.%s.svc.cluster.local" (include "airflow.postgresql.fullname" .) (.Release.Namespace) }} port=5432
 {{- else }}
-* = host={{ .Values.externalDatabase.host }} port={{ .Values.externalDatabase.port }}
+* = host={{ tpl .Values.externalDatabase.host . }} port={{ .Values.externalDatabase.port }}
 {{- end }}
 
 [pgbouncer]

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -97,8 +97,8 @@ spec:
         {{- if .Values.dags.gitSync.enabled }}
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- if .Values.scheduler.extraInitContainers }}
         {{- toYaml .Values.scheduler.extraInitContainers | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/sync/_helpers/sync_connections.tpl
+++ b/charts/airflow/templates/sync/_helpers/sync_connections.tpl
@@ -103,7 +103,7 @@ VAR__CONNECTION_WRAPPERS = {
     description={{ .description | quote }},
     {{- end }}
     {{- if .host }}
-    host={{ .host | quote }},
+    host={{ tpl .host $ | quote }},
     {{- end }}
     {{- if .login }}
     login={{ .login | quote }},
@@ -122,7 +122,7 @@ VAR__CONNECTION_WRAPPERS = {
     port={{ .port }},
     {{- end }}
     {{- if .extra }}
-    extra={{ .extra | quote }},
+    extra={{ tpl .extra $ | quote }},
     {{- end }}
   ),
   {{- end }}

--- a/charts/airflow/templates/sync/sync-connections-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-connections-deployment.yaml
@@ -83,8 +83,8 @@ spec:
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-connections
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-connections-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-connections-deployment.yaml
@@ -129,13 +129,13 @@ spec:
               {{- end }}
               {{- if eq ($v.kind | lower) "configmap" }}
               - configMap:
-                  name: {{ $v.name | quote }}
+                  name: {{ tpl $v.name $ | quote }}
                   items:
                     - key: {{ $v.key | quote }}
                       path: {{ $k | quote }}
               {{- else if eq ($v.kind | lower) "secret" }}
               - secret:
-                  name: {{ $v.name | quote }}
+                  name: {{ tpl $v.name $ | quote }}
                   items:
                     - key: {{ $v.key | quote }}
                       path: {{ $k | quote }}

--- a/charts/airflow/templates/sync/sync-connections-job.yaml
+++ b/charts/airflow/templates/sync/sync-connections-job.yaml
@@ -119,13 +119,13 @@ spec:
               {{- end }}
               {{- if eq ($v.kind | lower) "configmap" }}
               - configMap:
-                  name: {{ $v.name | quote }}
+                  name: {{ tpl $v.name $ | quote }}
                   items:
                     - key: {{ $v.key | quote }}
                       path: {{ $k | quote }}
               {{- else if eq ($v.kind | lower) "secret" }}
               - secret:
-                  name: {{ $v.name | quote }}
+                  name: {{ tpl $v.name $ | quote }}
                   items:
                     - key: {{ $v.key | quote }}
                       path: {{ $k | quote }}

--- a/charts/airflow/templates/sync/sync-connections-job.yaml
+++ b/charts/airflow/templates/sync/sync-connections-job.yaml
@@ -77,8 +77,8 @@ spec:
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-connections
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-pools-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-pools-deployment.yaml
@@ -83,8 +83,8 @@ spec:
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-pools
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-pools-job.yaml
+++ b/charts/airflow/templates/sync/sync-pools-job.yaml
@@ -77,8 +77,8 @@ spec:
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-pools
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-users-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-users-deployment.yaml
@@ -83,8 +83,8 @@ spec:
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-users
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-users-job.yaml
+++ b/charts/airflow/templates/sync/sync-users-job.yaml
@@ -77,8 +77,8 @@ spec:
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-users
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-variables-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-variables-deployment.yaml
@@ -83,8 +83,8 @@ spec:
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-variables
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-variables-job.yaml
+++ b/charts/airflow/templates/sync/sync-variables-job.yaml
@@ -77,8 +77,8 @@ spec:
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-variables
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -89,8 +89,8 @@ spec:
         {{- if .Values.dags.gitSync.enabled }}
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: airflow-web
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -94,8 +94,8 @@ spec:
         {{- if .Values.dags.gitSync.enabled }}
         {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Template" .Template "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: airflow-worker
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1624,6 +1624,14 @@ externalDatabase:
   ##
   user: airflow
 
+  ## the name of a pre-created secret containing the external database username
+  ##
+  userSecret: ""
+
+  ## the key within `externalDatabase.userSecret` containing the user string
+  ##
+  userSecretKey: "postgresql-user"
+
   ## the name of a pre-created secret containing the external database password
   ##
   passwordSecret: ""


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- fixes #511

When using [postgres-operator](https://opensource.zalando.com/postgres-operator/) alongside Airflow, it's not possible to mount the secrets that the operator creates to manage user credentials for the PostgreSQL instance.

## What does your PR do?

This PR does two things: 
1. it adds support for reading the database username used by the `externalDatabase` config block from a secret in the same manner as the password.
2. it adds support for using the Helm templating variables in a number of places: `externalDatabase.userSecret`, `externalDatabase.passwordSecret`, `externalDatabase.host`, within the `host` and `extra` fields of entries in `airflow.connections`, and in the `name` field of entries in `airflow.connectionsTemplates`. This allows the secrets that the operator creates which include either the release name or release namespace to be correctly rendered.


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [ ] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated