### PR TITLE
feat: allow `airflow.users[].roles` to specify a list of roles

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -424,7 +424,10 @@ airflow:
       lastName: admin
     - username: user
       password: user123
-      role: User
+      # TIP: `role` can be a single role or a list of roles
+      role: 
+        - User
+        - Viewer
       email: user@example.com
       firstName: user
       lastName: user

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -424,7 +424,7 @@ airflow:
       lastName: admin
     - username: user
       password: user123
-      # TIP: `role` can be a single role or a list of roles
+      ## TIP: `role` can be a single role or a list of roles
       role: 
         - User
         - Viewer

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -67,6 +67,7 @@ airflow:
   ## - templates can ONLY be used in: `password`, `email`, `firstName`, `lastName`
   ## - templates used a bash-like syntax: ${MY_USERNAME}, $MY_USERNAME
   ## - templates are defined in `usersTemplates`
+  ## - `role` can be a single role or an array
   ##
   users:
     - username: admin

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -67,7 +67,7 @@ airflow:
   ## - templates can ONLY be used in: `password`, `email`, `firstName`, `lastName`
   ## - templates used a bash-like syntax: ${MY_USERNAME}, $MY_USERNAME
   ## - templates are defined in `usersTemplates`
-  ## - `role` can be a single role or an array
+  ## - `role` can be a single role or a list of roles
   ##
   users:
     - username: admin


### PR DESCRIPTION
## What issues does your PR fix?

- resolves #538 

## What does your PR do?

- Alows `airflow.users[].roles` to be either a list of `flask_appbuilder` role-names, or a single role-name string.

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated