### PR TITLE
feat: set default `pgbouncer.maxClientConnections` to 1000

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1688,7 +1688,7 @@ Parameter | Description | Default
 `pgbouncer.podDisruptionBudget.*` | configs for the PodDisruptionBudget of the pgbouncer | `<see values.yaml>`
 `pgbouncer.livenessProbe.*` | configs for the pgbouncer Pods' liveness probe | `<see values.yaml>`
 `pgbouncer.terminationGracePeriodSeconds` | the maximum number of seconds to wait for queries upon pod termination, before force killing | `120`
-`pgbouncer.maxClientConnections` | sets pgbouncer config: `max_client_conn` | `100`
+`pgbouncer.maxClientConnections` | sets pgbouncer config: `max_client_conn` | `1000`
 `pgbouncer.poolSize` | sets pgbouncer config: `default_pool_size` | `20`
 `pgbouncer.logDisconnections` | sets pgbouncer config: `log_disconnections` | `0`
 `pgbouncer.logConnections` | sets pgbouncer config: `log_connections` | `0`

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1447,7 +1447,7 @@ pgbouncer:
 
   ## sets pgbouncer config: `max_client_conn`
   ##
-  maxClientConnections: 100
+  maxClientConnections: 1000
 
   ## sets pgbouncer config: `default_pool_size`
   ##


### PR DESCRIPTION
## What issues does your PR fix?

- N/A

## What does your PR do?

- Increases the default `pgbouncer.maxClientConnections` from `100` to `1000`
   - ___NOTE:__ `1000` is well beyond what should be required in most deployments, so this should prevent users from running into a confusing situation where the connection limit is exceeded, and random things start failing (with the only error logs being in the PGBouncer deployment)_


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated