### PR TITLE
fix: update default `dags.gitSync.image.tag` to v3.5.0

### DIFF
--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1080,7 +1080,7 @@ dags:
     ##
     image:
       repository: k8s.gcr.io/git-sync/git-sync
-      tag: v3.2.2
+      tag: v3.5.0
       pullPolicy: IfNotPresent
       uid: 65533
       gid: 65533


### PR DESCRIPTION
## What issues does your PR fix?

- fixes https://github.com/airflow-helm/charts/issues/414
- related to https://github.com/airflow-helm/charts/issues/518

## What does your PR do?

- Updates the default `dags.gitSync.image.tag` from `v3.2.2` to `v3.5.0`


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated