### PR TITLE
fix: `pgbouncer.livenessProbe.enabled` not being respected

### DIFF
--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -104,6 +104,7 @@ spec:
             - |-
               /home/pgbouncer/config/gen_auth_file.sh && \
               exec pgbouncer /home/pgbouncer/config/pgbouncer.ini
+          {{- if .Values.pgbouncer.livenessProbe.enabled }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.pgbouncer.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.pgbouncer.livenessProbe.periodSeconds }}
@@ -116,6 +117,7 @@ spec:
                 ## this check is intended to fail when the DATABASE_PASSWORD secret is updated,
                 ## which would cause `gen_auth_file.sh` to run again on container start
                 - psql $(eval $DATABASE_PSQL_CMD) --tuples-only --command="SELECT 1;" | grep -q "1"
+          {{- end }}
           readinessProbe:
             initialDelaySeconds: 5
             periodSeconds: 10


### PR DESCRIPTION
## What issues does your PR fix?

N/A

## What does your PR do?

- Fixes the `pgbouncer.livenessProbe.enabled` value not being respected

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated