### PR TITLE
fix: replace pgbouncer readinessProbe with startupProbe

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1788,6 +1788,7 @@ Parameter | Description | Default
 `pgbouncer.safeToEvict` | if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true" | `true`
 `pgbouncer.podDisruptionBudget.*` | configs for the PodDisruptionBudget of the pgbouncer | `<see values.yaml>`
 `pgbouncer.livenessProbe.*` | configs for the pgbouncer Pods' liveness probe | `<see values.yaml>`
+`pgbouncer.startupProbe.*` | configs for the pgbouncer Pods' startup probe | `<see values.yaml>`
 `pgbouncer.terminationGracePeriodSeconds` | the maximum number of seconds to wait for queries upon pod termination, before force killing | `120`
 `pgbouncer.maxClientConnections` | sets pgbouncer config: `max_client_conn` | `100`
 `pgbouncer.poolSize` | sets pgbouncer config: `default_pool_size` | `20`

--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -118,13 +118,15 @@ spec:
                 ## which would cause `gen_auth_file.sh` to run again on container start
                 - psql $(eval $DATABASE_PSQL_CMD) --tuples-only --command="SELECT 1;" | grep -q "1"
           {{- end }}
-          readinessProbe:
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+          {{- if .Values.pgbouncer.startupProbe.enabled }}
+          startupProbe:
+            initialDelaySeconds: {{ .Values.pgbouncer.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.pgbouncer.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.pgbouncer.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.pgbouncer.startupProbe.failureThreshold }}
             tcpSocket:
               port: 6432
+          {{- end }}
           volumeMounts:
             - name: pgbouncer-config
               mountPath: /home/pgbouncer/config

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1489,6 +1489,15 @@ pgbouncer:
     timeoutSeconds: 60
     failureThreshold: 3
 
+  ## configs for the pgbouncer Pods' startup probe
+  ##
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 30
+
   ## the maximum number of seconds to wait for queries upon pod termination, before force killing
   ##
   terminationGracePeriodSeconds: 120


### PR DESCRIPTION
## What issues does your PR fix?

- fixes https://github.com/airflow-helm/charts/issues/525
- resolves https://github.com/airflow-helm/charts/issues/526

## What does your PR do?

- Replaces the PgBouncer "readinessProbe" with a "startupProbe" to prevent intermittent socket failures causing the "livenessProbe" to fail:
   - ___WARNING:__ "startupProbe" was made [beta in Kubernetes 1.18](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#features-graduated-to-beta), so older versions of Kubernetes may not respect the "startupProbe"_
   - ___NOTE:__ see https://github.com/airflow-helm/charts/issues/526 for context_
- Added the following values:
   - `pgbouncer.startupProbe.enabled` (default: `true`)
   - `pgbouncer.startupProbe.initialDelaySeconds` (default: `5`)
   - `pgbouncer.startupProbe.periodSeconds` (default: `10`)
   - `pgbouncer.startupProbe.timeoutSeconds` (default: `15`)
   - `pgbouncer.startupProbe.failureThreshold` (default: `30`)


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated