### PR TITLE
feat: add "task creation check" to scheduler liveness probe

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1049,7 +1049,7 @@ Each scheduler will perform a "heartbeat" every `AIRFLOW__SCHEDULER__SCHEDULER_H
 > The scheduler can have a "heartbeat" but be deadlocked such that it's unable to schedule new tasks,
 > we provide the `scheduler.livenessProbe.taskCreationCheck.*` values to automatically restart the scheduler in these cases.
 >
-> https://github.com/apache/airflow/issues/7935 - patched in airflow `2.0.2`
+> https://github.com/apache/airflow/issues/7935 - patched in airflow `2.0.2`<br>
 > https://github.com/apache/airflow/issues/15938 - patched in airflow `2.1.1`
 
 By default, the chart runs a liveness probe every __30 seconds__ (`periodSeconds`), and will restart a scheduler if __5 probe failures__ (`failureThreshold`) occur in a row.

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1031,6 +1031,123 @@ serviceAccount:
 <hr>
 </details>
 
+### How to configure the scheduler liveness probe?
+<details>
+<summary>Expand</summary>
+<hr>
+
+> 🟥 __Warning__ 🟥
+>
+> The scheduler can have a "heartbeat" but be deadlocked such that it's unable to schedule new tasks until being restarted,
+> we provide the `scheduler.livenessProbe.taskCreationCheck.*` values to automatically restart the scheduler in these cases.
+>
+> Deadlock issue reference:
+>
+> - https://github.com/apache/airflow/issues/7935
+>    - present in all versions until being patched in `2.0.2`
+> - https://github.com/apache/airflow/issues/15938
+>    - present in versions from `1.10.13` until being patched in `2.1.1`
+
+<h3>Scheduler "Heartbeat Check"</h3>
+
+The chart includes a [Kubernetes Liveness Probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) 
+for each airflow scheduler which regularly queries the Airflow Metadata Database to ensure the scheduler is ["healthy"](https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/check-health.html).
+
+A scheduler is "healthy" if it has had a "heartbeat" in the last `AIRFLOW__SCHEDULER__SCHEDULER_HEALTH_CHECK_THRESHOLD` seconds.
+Each scheduler will perform a "heartbeat" every `AIRFLOW__SCHEDULER__SCHEDULER_HEARTBEAT_SEC` seconds by updating the `latest_heartbeat` of its `SchedulerJob` in the Airflow Metadata `jobs` table.
+
+By default, the chart runs a liveness probe every __30 seconds__ (`periodSeconds`), and will restart a scheduler if __5 probe failures__ (`failureThreshold`) occur in a row.
+This means a scheduler must be unhealthy for at least `30 x 5 = 150` seconds before Kubernetes will automatically restart a scheduler Pod.
+
+Here is an overview of the `scheduler.livenessProbe.*` values:
+
+```yaml
+scheduler:
+  livenessProbe:
+    enabled: true
+    
+    ## number of seconds to wait after a scheduler container starts before running its first probe
+    ## NOTE: schedulers take a few seconds to actually start
+    initialDelaySeconds: 10
+    
+    ## number of seconds to wait between each probe
+    periodSeconds: 30
+    
+    ## maximum number of seconds that a probe can take before timing out
+    ## WARNING: if your database is very slow, you may need to increase this value to prevent invalid scheduler restarts
+    timeoutSeconds: 60
+    
+    ## maximum number of consecutive probe failures, after which the scheduler will be restarted
+    ## NOTE: a "failure" could be any of:
+    ##  1. the probe takes more than `timeoutSeconds`
+    ##  2. the probe detects the scheduler as "unhealthy"
+    ##  3. the probe "task creation check" fails
+    failureThreshold: 5
+```
+
+<h3>Scheduler "Task Creation Check"</h3>
+
+> 🟨 __Note__ 🟨
+>
+> The "Task Creation Check" is currently disabled by default, it can be enabled with `scheduler.livenessProbe.taskCreationCheck.enabled`, but please read the following section first!
+
+The liveness probe can additionally check if the Scheduler is creating new [tasks](https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html) as an indication of its health. 
+This check works by ensuring that the most recent `LocalTaskJob` had a `start_date` no more than `scheduler.livenessProbe.taskCreationCheck.thresholdSeconds` seconds ago.
+
+Here is an overview of the `scheduler.livenessProbe.taskCreationCheck.*` values:
+
+```yaml
+scheduler:
+  livenessProbe:
+    enabled: true
+    ...
+    
+    taskCreationCheck:
+      ## if the task creation check is enabled
+      enabled: true
+
+      ## the maximum number of seconds since the start_date of the most recent LocalTaskJob
+      ## WARNING: must be AT LEAST equal to your shortest DAG schedule_interval
+      ## WARNING: DummyOperator tasks will NOT be seen by this probe
+      thresholdSeconds: 300
+```
+
+You might use the following `canary_dag` DAG definition to run a small task every __300 seconds__ (5 minutes):
+
+```python
+from datetime import datetime, timedelta
+from airflow import DAG
+
+# import using try/except to support both airflow 1 and 2
+try:
+    from airflow.operators.bash import BashOperator
+except ModuleNotFoundError:
+    from airflow.operators.bash_operator import BashOperator
+
+dag = DAG(
+    dag_id="canary_dag",
+    default_args={
+        "owner": "airflow",
+    },
+    schedule_interval="*/5 * * * *",
+    start_date=datetime(2022, 1, 1),
+    dagrun_timeout=timedelta(minutes=5),
+    is_paused_upon_creation=False,
+    catchup=False,
+)
+
+# WARNING: while `DummyOperator` would use less resources, the check can't see those tasks 
+#          as they don't create LocalTaskJob instances
+task = BashOperator(
+    task_id="canary_task",
+    bash_command="echo 'Hello World!'",
+    dag=dag,
+)
+```
+
+<hr>
+</details>
+
 ## FAQ - Databases
 
 > __Frequently asked questions related to database configs__

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1036,18 +1036,6 @@ serviceAccount:
 <summary>Expand</summary>
 <hr>
 
-> 🟥 __Warning__ 🟥
->
-> The scheduler can have a "heartbeat" but be deadlocked such that it's unable to schedule new tasks until being restarted,
-> we provide the `scheduler.livenessProbe.taskCreationCheck.*` values to automatically restart the scheduler in these cases.
->
-> Deadlock issue reference:
->
-> - https://github.com/apache/airflow/issues/7935
->    - present in all versions until being patched in `2.0.2`
-> - https://github.com/apache/airflow/issues/15938
->    - present in versions from `1.10.13` until being patched in `2.1.1`
-
 <h3>Scheduler "Heartbeat Check"</h3>
 
 The chart includes a [Kubernetes Liveness Probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) 
@@ -1055,6 +1043,14 @@ for each airflow scheduler which regularly queries the Airflow Metadata Database
 
 A scheduler is "healthy" if it has had a "heartbeat" in the last `AIRFLOW__SCHEDULER__SCHEDULER_HEALTH_CHECK_THRESHOLD` seconds.
 Each scheduler will perform a "heartbeat" every `AIRFLOW__SCHEDULER__SCHEDULER_HEARTBEAT_SEC` seconds by updating the `latest_heartbeat` of its `SchedulerJob` in the Airflow Metadata `jobs` table.
+
+> 🟥 __Warning__ 🟥
+>
+> The scheduler can have a "heartbeat" but be deadlocked such that it's unable to schedule new tasks,
+> we provide the `scheduler.livenessProbe.taskCreationCheck.*` values to automatically restart the scheduler in these cases.
+>
+> https://github.com/apache/airflow/issues/7935 - patched in airflow `2.0.2`
+> https://github.com/apache/airflow/issues/15938 - patched in airflow `2.1.1`
 
 By default, the chart runs a liveness probe every __30 seconds__ (`periodSeconds`), and will restart a scheduler if __5 probe failures__ (`failureThreshold`) occur in a row.
 This means a scheduler must be unhealthy for at least `30 x 5 = 150` seconds before Kubernetes will automatically restart a scheduler Pod.
@@ -1087,12 +1083,12 @@ scheduler:
 
 <h3>Scheduler "Task Creation Check"</h3>
 
-> 🟨 __Note__ 🟨
->
-> The "Task Creation Check" is currently disabled by default, it can be enabled with `scheduler.livenessProbe.taskCreationCheck.enabled`, but please read the following section first!
-
 The liveness probe can additionally check if the Scheduler is creating new [tasks](https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html) as an indication of its health. 
 This check works by ensuring that the most recent `LocalTaskJob` had a `start_date` no more than `scheduler.livenessProbe.taskCreationCheck.thresholdSeconds` seconds ago.
+
+> 🟦 __Tip__ 🟦
+>
+> The "Task Creation Check" is currently disabled by default, it can be enabled with `scheduler.livenessProbe.taskCreationCheck.enabled`.
 
 Here is an overview of the `scheduler.livenessProbe.taskCreationCheck.*` values:
 

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1046,7 +1046,7 @@ Each scheduler will perform a "heartbeat" every `AIRFLOW__SCHEDULER__SCHEDULER_H
 
 > 🟥 __Warning__ 🟥
 >
-> The scheduler can have a "heartbeat" but be deadlocked such that it's unable to schedule new tasks,
+> A scheduler can have a "heartbeat" but be deadlocked such that it's unable to schedule new tasks,
 > we provide the `scheduler.livenessProbe.taskCreationCheck.*` values to automatically restart the scheduler in these cases.
 >
 > https://github.com/apache/airflow/issues/7935 - patched in airflow `2.0.2`<br>

--- a/charts/airflow/templates/NOTES.txt
+++ b/charts/airflow/templates/NOTES.txt
@@ -74,6 +74,18 @@
 {{- $known_host_warning = true }}
 {{- end }}
 
+{{- /* if we show the scheduler livenessProbe warning */ -}}
+{{- $scheduler_livenessProbe_warning := false }}
+{{- if not .Values.scheduler.livenessProbe.enabled }}
+{{- $scheduler_livenessProbe_warning = true }}
+{{- end }}
+
+{{- /* if we show the scheduler livenessProbe taskCreationCheck warning */ -}}
+{{- $scheduler_livenessProbe_taskCreationCheck_warning := false }}
+{{- if and (.Values.scheduler.livenessProbe.enabled) (not .Values.scheduler.livenessProbe.taskCreationCheck.enabled) }}
+{{- $scheduler_livenessProbe_taskCreationCheck_warning = true }}
+{{- end }}
+
 ========================================================================
 Thanks for deploying Apache Airflow with the User-Community Helm Chart!
 
@@ -157,6 +169,16 @@ Use these commands to port-forward the Services to your localhost:
 {{- if $known_host_warning }}
 [HIGH] git-sync ssh known_hosts verification is disabled!
   * HELP: set `dags.gitSync.sshKnownHosts` with the ssh fingerprint of your git host
+{{ end }}
+
+{{- if $scheduler_livenessProbe_warning }}
+[MEDIUM] the scheduler liveness probe is disabled, the scheduler may not be restarted if it becomes unhealthy!
+  * HELP: enable the probe with `scheduler.livenessProbe.enabled`
+{{ end }}
+
+{{- if $scheduler_livenessProbe_taskCreationCheck_warning }}
+[MEDIUM] the scheduler liveness probe "task creation check" is disabled, the scheduler may not be restarted if it deadlocks!
+  * HELP: configure the check with `scheduler.livenessProbe.taskCreationCheck.*`
 {{ end }}
 
 {{- end }}

--- a/charts/airflow/templates/NOTES.txt
+++ b/charts/airflow/templates/NOTES.txt
@@ -177,7 +177,7 @@ Use these commands to port-forward the Services to your localhost:
 {{ end }}
 
 {{- if $scheduler_livenessProbe_taskCreationCheck_warning }}
-[MEDIUM] the scheduler liveness probe "task creation check" is disabled, the scheduler may not be restarted if it deadlocks!
+[MEDIUM] the scheduler "task creation check" is disabled, the scheduler may not be restarted if it deadlocks!
   * HELP: configure the check with `scheduler.livenessProbe.taskCreationCheck.*`
 {{ end }}
 

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -125,34 +125,66 @@ spec:
             timeoutSeconds: {{ .Values.scheduler.livenessProbe.timeoutSeconds }}
             exec:
               command:
+                {{- include "airflow.command" . | indent 16 }}
                 - "python"
                 - "-Wignore"
                 - "-c"
                 - |
+                  import os
                   import sys
-                  from typing import List
+
+                  # suppress logs triggered from importing airflow packages
+                  {{- if .Values.airflow.legacyCommands }}
+                  os.environ["AIRFLOW__CORE__LOGGING_LEVEL"] = "ERROR"
+                  {{- else }}
+                  os.environ["AIRFLOW__LOGGING__LOGGING_LEVEL"] = "ERROR"
+                  {{- end }}
+
                   from airflow.jobs.scheduler_job import SchedulerJob
                   from airflow.utils.db import create_session
                   from airflow.utils.net import get_hostname
-                  from airflow.utils.state import State
+                  {{- if .Values.scheduler.livenessProbe.taskCreationCheck.enabled }}
+                  from airflow.jobs.local_task_job import LocalTaskJob
+                  from airflow.utils import timezone
+                  {{- end }}
 
                   with create_session() as session:
+                      # ensure the SchedulerJob with most recent heartbeat for this `hostname` is alive
                       hostname = get_hostname()
-                      query = session \
+                      scheduler_job = session \
                           .query(SchedulerJob) \
-                          .filter_by(state=State.RUNNING, hostname=hostname) \
-                          .order_by(SchedulerJob.latest_heartbeat.desc())
-                      jobs: List[SchedulerJob] = query.all()
-                      alive_jobs = [job for job in jobs if job.is_alive()]
-                      count_alive_jobs = len(alive_jobs)
+                          .filter_by(hostname=hostname) \
+                          .order_by(SchedulerJob.latest_heartbeat.desc()) \
+                          .limit(1) \
+                          .first()
+                      if (scheduler_job is not None) and scheduler_job.is_alive():
+                          pass
+                      else:
+                          sys.exit(f"The SchedulerJob (id={scheduler_job.id}) for hostname '{hostname}' is not alive")
 
-                  if count_alive_jobs == 1:
-                      # scheduler is healthy - we expect one SchedulerJob per scheduler
-                      pass
-                  elif count_alive_jobs == 0:
-                      sys.exit(f"UNHEALTHY - 0 alive SchedulerJob for: {hostname}")
-                  else:
-                      sys.exit(f"UNHEALTHY - {count_alive_jobs} (more than 1) alive SchedulerJob for: {hostname}")
+                      {{- if .Values.scheduler.livenessProbe.taskCreationCheck.enabled }}
+                      {{- $task_job_threshold := .Values.scheduler.livenessProbe.taskCreationCheck.thresholdSeconds }}
+                      {{- if not (or (typeIs "float64" $task_job_threshold) (typeIs "int64" $task_job_threshold)) }}
+                      {{- /* the type of a number could be float64 or int64 depending on how it was set (values.yaml, or --set) */ -}}
+                      {{ required (printf "`scheduler.livenessProbe.taskCreationCheck.thresholdSeconds` must be int-type, but got %s!" (typeOf $task_job_threshold)) nil }}
+                      {{- end }}
+
+                      # ensure the most recent LocalTaskJob had a start_date in the last `task_job_threshold` seconds
+                      task_job_threshold = {{ $task_job_threshold }}
+                      task_job = session \
+                          .query(LocalTaskJob) \
+                          .order_by(LocalTaskJob.id.desc()) \
+                          .limit(1) \
+                          .first()
+                      if task_job is not None:
+                          if (timezone.utcnow() - task_job.start_date).total_seconds() < task_job_threshold:
+                              pass
+                          else:
+                              sys.exit(
+                                  f"The most recent LocalTaskJob (id={task_job.id}, dag_id={task_job.dag_id}) "
+                                  f"started over {task_job_threshold} seconds ago"
+                              )
+                      {{- end }}
           {{- end }}
           {{- if or ($volumeMounts) (include "airflow.executor.kubernetes_like" .) }}
           volumeMounts:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -541,8 +541,8 @@ scheduler:
     ## - this check works by ensuring that the most recent LocalTaskJob had a `start_date` no more than
     ##   `taskCreationCheck.thresholdSeconds` seconds ago
     ## - this check is useful because the scheduler can deadlock with a heartbeat, but not be scheduling new tasks:
-    ##   - https://github.com/apache/airflow/issues/7935 (present in all versions until being patched in `2.0.2`)
-    ##   - https://github.com/apache/airflow/issues/15938 (present from `1.10.13` until being patched in `2.1.1`)
+    ##   https://github.com/apache/airflow/issues/7935 - patched in airflow `2.0.2`
+    ##   https://github.com/apache/airflow/issues/15938 - patched in airflow `2.1.1`
     ##
     taskCreationCheck:
       ## if the task creation check is enabled

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -526,7 +526,9 @@ scheduler:
   numRuns: -1
 
   ## configs for the scheduler Pods' liveness probe
-  ## - `periodSeconds` x `failureThreshold` = max seconds a scheduler can be unhealthy
+  ## - "unhealthy" means the SchedulerJob has not had a heartbeat for
+  ##   AIRFLOW__SCHEDULER__SCHEDULER_HEALTH_CHECK_THRESHOLD seconds
+  ## - `periodSeconds` x `failureThreshold` = max seconds a scheduler can be in an "unhealthy" state
   ##
   livenessProbe:
     enabled: true
@@ -534,6 +536,24 @@ scheduler:
     periodSeconds: 30
     timeoutSeconds: 60
     failureThreshold: 5
+
+    ## configs for an additional check that ensures tasks are being created by the scheduler
+    ## - this check works by ensuring that the most recent LocalTaskJob had a `start_date` no more than
+    ##   `taskCreationCheck.thresholdSeconds` seconds ago
+    ## - this check is useful because the scheduler can deadlock with a heartbeat, but not be scheduling new tasks:
+    ##   - https://github.com/apache/airflow/issues/7935 (present in all versions until being patched in `2.0.2`)
+    ##   - https://github.com/apache/airflow/issues/15938 (present from `1.10.13` until being patched in `2.1.1`)
+    ##
+    taskCreationCheck:
+      ## if the task creation check is enabled
+      ##
+      enabled: false
+
+      ## the maximum number of seconds since the start_date of the most recent LocalTaskJob
+      ## - [WARNING] must be AT LEAST equal to your shortest DAG schedule_interval
+      ## - [WARNING] DummyOperator tasks will NOT be seen by this probe
+      ##
+      thresholdSeconds: 300
 
   ## extra pip packages to install in the scheduler Pods
   ##


### PR DESCRIPTION
## What issues does your PR fix?

- related to #512 
   -  _(NOTE: this PR probably does not fix that issue fully)_
- supersedes https://github.com/airflow-helm/charts/pull/541

## What does your PR do?

- Adds an optional "task creation check" to the scheduler liveness probe:
    - `scheduler.livenessProbe.taskCreationCheck.enabled` (default: `false`)
    - `scheduler.livenessProbe.taskCreationCheck.thresholdSeconds` (default: `300`)
- Adds a new FAQ "How to configure the scheduler liveness probe?" with sub-sections:
    - `Scheduler "Heartbeat Check"`
    - `Scheduler "Task Creation Check"`
- Runs the scheduler livenessProbe with `/entrypoint`:
    - ___NOTE:__ this ensures any fixes inside `/entrypoint` are applied in our livenessProbe_
    - ___NOTE:__ this improves support for running as root (airflow python packages will not be visible otherwise)_
- Makes the scheduler livenessProbe use fewer resources by:
    1. Only querying the `.first()` instance of `SchedulerJob` from the database
    2. Setting airflow log-level to ERROR
    3. Running python under `dumb-init` (so processes are cleaned up)


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated