### PR TITLE
fix: set `DUMB_INIT_SETSID=0` for celery workers (warm shutdown) 

### DIFF
--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -153,10 +153,9 @@ spec:
               protocol: TCP
           command:
             {{- include "airflow.command" . | indent 12 }}
-            ## required because `/entrypoint` only passes "bash" / "python", and our `lifecycle.preStop` uses "timeout"
+          args:
             - "bash"
             - "-c"
-          args:
             {{- if .Values.airflow.legacyCommands }}
             - "exec airflow worker"
             {{- else }}

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -105,6 +105,9 @@ spec:
             {{- include "airflow.envFrom" . | indent 12 }}
           env:
             {{- include "airflow.env" . | indent 12 }}
+            # have dumb-init only send signals to direct child process (needed for celery workers to warm shutdown)
+            - name: DUMB_INIT_SETSID
+              value: "0"
           {{- if .Values.workers.celery.gracefullTermination }}
           lifecycle:
             preStop:


### PR DESCRIPTION
## What issues does your PR fix?

- resolves https://github.com/airflow-helm/charts/issues/428

## What does your PR do?

- Sets `DUMB_INIT_SETSID=0` on the celery workers:
   - makes dumb-init only send SIGTERM/SIGKILL/etc to direct child process (needed for celery workers to warm shutdown successfully)
- Makes the Airflow Celery Worker containers use the same `command` (entrypoint) as the rest of the Airflow Deployments
    - ___NOTE:__ our previous reasonsing for including `bash -c` in the `command` was invalid, as `lifecycle.preStop` does not run with the containers defined `command`, but by directly `exec`'ing into the container)_

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated