### PR TITLE
feat: update pgbouncer image tag `1.17.0-patch.0`

### DIFF
--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1362,7 +1362,7 @@ pgbouncer:
   ##
   image:
     repository: ghcr.io/airflow-helm/pgbouncer
-    tag: 1.15.0-patch.0
+    tag: 1.17.0-patch.0
     pullPolicy: IfNotPresent
     uid: 1001
     gid: 1001


### PR DESCRIPTION
## What issues does your PR fix?

- related to https://github.com/airflow-helm/charts/issues/397

## What does your PR do?

- Updates the default PGBouncer image to `ghcr.io/airflow-helm/pgbouncer:1.17.0-patch.0`


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated