### PR TITLE
feat: database passwords with values + username from secret

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1114,11 +1114,11 @@ IBM Cloud | [IBM Cloud® Databases for PostgreSQL](https://cloud.ibm.com/docs/da
 Example values for an external Postgres database, with an existing `airflow_cluster1` database:
 ```yaml
 postgresql:
-  # to use the external db, the embedded one must be disabled
+  ## to use the external db, the embedded one must be disabled
   enabled: false
 
 pgbouncer:
-  # for other PgBouncer configs, see the `pgbouncer.*` values
+  ## for other PgBouncer configs, see the `pgbouncer.*` values
   enabled: true
 
 externalDatabase:
@@ -1127,24 +1127,24 @@ externalDatabase:
   host: postgres.example.org
   port: 5432
   
-  # the schema which will contain the airflow tables
+  ## the schema which will contain the airflow tables
   database: airflow_cluster1
 
-  # (username - option 1) a plain-text helm value
+  ## (username - option 1) a plain-text helm value
   user: my_airflow_user
   
-  # (username - option 2) a Kubernetes secret in your airflow namespace
+  ## (username - option 2) a Kubernetes secret in your airflow namespace
   #userSecret: "airflow-cluster1-database-credentials"
   #userSecretKey: "username"
 
-  # (password - option 1) a plain-text helm value
+  ## (password - option 1) a plain-text helm value
   password: my_airflow_password
 
-  # (password - option 2) a Kubernetes secret in your airflow namespace
+  ## (password - option 2) a Kubernetes secret in your airflow namespace
   #passwordSecret: "airflow-cluster1-database-credentials"
   #passwordSecretKey: "password"
 
-  # use this for any extra connection-string settings, e.g. ?sslmode=disable
+  ## use this for any extra connection-string settings, e.g. ?sslmode=disable
   properties: ""
 ```
 
@@ -1157,11 +1157,11 @@ externalDatabase:
 Example values for an external MySQL database, with an existing `airflow_cluster1` database:
 ```yaml
 postgresql:
-  # to use the external db, the embedded one must be disabled
+  ## to use the external db, the embedded one must be disabled
   enabled: false
 
 pgbouncer:
-  # pgbouncer is automatically disabled if `externalDatabase.type` is `mysql`
+  ## pgbouncer is automatically disabled if `externalDatabase.type` is `mysql`
   #enabled: false
 
 externalDatabase:
@@ -1170,24 +1170,24 @@ externalDatabase:
   host: mysql.example.org
   port: 3306
 
-  # the database which will contain the airflow tables
+  ## the database which will contain the airflow tables
   database: airflow_cluster1
 
-  # (username - option 1) a plain-text helm value
+  ## (username - option 1) a plain-text helm value
   user: my_airflow_user
 
-  # (username - option 2) a Kubernetes secret in your airflow namespace
+  ## (username - option 2) a Kubernetes secret in your airflow namespace
   #userSecret: "airflow-cluster1-database-credentials"
   #userSecretKey: "username"
 
-  # (password - option 1) a plain-text helm value
+  ## (password - option 1) a plain-text helm value
   password: my_airflow_password
 
-  # (password - option 2) a Kubernetes secret in your airflow namespace
+  ## (password - option 2) a Kubernetes secret in your airflow namespace
   #passwordSecret: "airflow-cluster1-database-credentials"
   #passwordSecretKey: "password"
 
-  # use this for any extra connection-string settings, e.g. ?useSSL=false
+  ## use this for any extra connection-string settings, e.g. ?useSSL=false
   properties: ""
 ```
 
@@ -1208,17 +1208,17 @@ externalRedis:
   host: "example.redis.cache.windows.net"
   port: 6380
   
-  # the redis database-number that airflow will use
+  ## the redis database-number that airflow will use
   databaseNumber: 1
 
-  # (option 1 - password) a plain-text helm value
+  ## (option 1 - password) a plain-text helm value
   password: my_airflow_password
 
-  # (option 2 - password) a Kubernetes secret in your airflow namespace
+  ## (option 2 - password) a Kubernetes secret in your airflow namespace
   #passwordSecret: "airflow-cluster1-redis-credentials"
   #passwordSecretKey: "password"
 
-  # use this for any extra connection-string settings
+  ## use this for any extra connection-string settings
   properties: "?ssl_cert_reqs=CERT_OPTIONAL"
 ```
 

--- a/charts/airflow/templates/NOTES.txt
+++ b/charts/airflow/templates/NOTES.txt
@@ -46,6 +46,24 @@
   {{- end }}
 {{- end }}
 
+{{- /* if we show the external database password warning */ -}}
+{{- $external_database_password_warning := false }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.externalDatabase.passwordSecret) }}
+  {{- /* don't show a warning if the password is empty */ -}}
+  {{- if .Values.externalDatabase.password }}
+  {{- $external_database_password_warning = true }}
+  {{- end }}
+{{- end }}
+
+{{- /* if we show the external redis password warning */ -}}
+{{- $external_redis_password_warning := false }}
+{{- if and (not .Values.redis.enabled) (not .Values.externalRedis.passwordSecret) }}
+  {{- /* don't show a warning if the password is empty */ -}}
+  {{- if .Values.externalRedis.password }}
+  {{- $external_redis_password_warning = true }}
+  {{- end }}
+{{- end }}
+
 {{- /* if we show the extraPipPackages warning */ -}}
 {{- $extra_pip_warning := false }}
 {{- if .Values.airflow.extraPipPackages }}
@@ -142,6 +160,16 @@ Use these commands to port-forward the Services to your localhost:
 {{- if $web_secret_warning }}
 [CRITICAL] default webserver secret_key value!
   * HELP: set a custom value with `airflow.webserverSecretKey` or `AIRFLOW__WEBSERVER__SECRET_KEY`
+{{ end }}
+
+{{- if $external_database_password_warning }}
+[CRITICAL] external database password is set using plain-text value!
+  * HELP: create a Kubernetes secret with your database password and configure `externalDatabase.passwordSecret`
+{{ end }}
+
+{{- if $external_redis_password_warning }}
+[CRITICAL] external redis password is set using plain-text value!
+  * HELP: create a Kubernetes secret with your redis password and configure `externalRedis.passwordSecret`
 {{ end }}
 
 {{- if $extra_pip_warning }}

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -410,7 +410,23 @@ The list of `envFrom` for web/scheduler/worker/flower Pods
 The list of `env` for web/scheduler/worker/flower Pods
 */}}
 {{- define "airflow.env" }}
-{{- /* postgres environment variables */ -}}
+{{- /* set DATABASE_USER */ -}}
+{{- if .Values.postgresql.enabled }}
+- name: DATABASE_USER
+  value: {{ .Values.postgresql.postgresqlUsername | quote }}
+{{- else }}
+{{- if .Values.externalDatabase.userSecret }}
+- name: DATABASE_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.externalDatabase.userSecret }}
+      key: {{ .Values.externalDatabase.userSecretKey }}
+{{- else }}
+{{- /* in this case, DATABASE_USER is set in the `-config-envs` Secret */ -}}
+{{- end }}
+{{- end }}
+
+{{- /* set DATABASE_PASSWORD */ -}}
 {{- if .Values.postgresql.enabled }}
 {{- if .Values.postgresql.existingSecret }}
 - name: DATABASE_PASSWORD
@@ -433,12 +449,11 @@ The list of `env` for web/scheduler/worker/flower Pods
       name: {{ .Values.externalDatabase.passwordSecret }}
       key: {{ .Values.externalDatabase.passwordSecretKey }}
 {{- else }}
-- name: DATABASE_PASSWORD
-  value: ""
+{{- /* in this case, DATABASE_PASSWORD is set in the `-config-envs` Secret */ -}}
 {{- end }}
 {{- end }}
 
-{{- /* redis environment variables */ -}}
+{{- /* set REDIS_PASSWORD */ -}}
 {{- if .Values.redis.enabled }}
 {{- if .Values.redis.existingSecret }}
 - name: REDIS_PASSWORD
@@ -461,8 +476,7 @@ The list of `env` for web/scheduler/worker/flower Pods
       name: {{ .Values.externalRedis.passwordSecret }}
       key: {{ .Values.externalRedis.passwordSecretKey }}
 {{- else }}
-- name: REDIS_PASSWORD
-  value: ""
+{{- /* in this case, REDIS_PASSWORD is set in the `-config-envs` Secret */ -}}
 {{- end }}
 {{- end }}
 

--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -31,12 +31,24 @@ data:
 
   ## database configs
   {{- if .Values.postgresql.enabled }}
-  DATABASE_USER: {{ .Values.postgresql.postgresqlUsername | b64enc | quote }}
   DATABASE_DB: {{ .Values.postgresql.postgresqlDatabase | b64enc | quote }}
   {{- else }}
-  DATABASE_USER: {{ .Values.externalDatabase.user | b64enc | quote }}
   DATABASE_DB: {{ .Values.externalDatabase.database | b64enc | quote }}
   DATABASE_PROPERTIES: {{ .Values.externalDatabase.properties | b64enc | quote }}
+  {{- end }}
+
+  {{- /* in other cases, these variables are set in the "airflow.env" template */ -}}
+  {{- if not .Values.postgresql.enabled }}
+  {{- if or (not .Values.externalDatabase.userSecret ) (not .Values.externalDatabase.passwordSecret) }}
+
+  ## database credentials (from plain-text helm values)
+  {{- if not .Values.externalDatabase.userSecret }}
+  DATABASE_USER: {{ .Values.externalDatabase.user | b64enc | quote }}
+  {{- end }}
+  {{- if not .Values.externalDatabase.passwordSecret }}
+  DATABASE_PASSWORD: {{ .Values.externalDatabase.password | b64enc | quote }}
+  {{- end }}
+  {{- end }}
   {{- end }}
 
   ## bash command which echos the URL encoded value of $DATABASE_USER
@@ -80,6 +92,15 @@ data:
   REDIS_PORT: {{ .Values.externalRedis.port | toString | b64enc | quote }}
   REDIS_DBNUM: {{ .Values.externalRedis.databaseNumber | toString | b64enc | quote }}
   REDIS_PROPERTIES: {{.Values.externalRedis.properties | b64enc | quote }}
+  {{- end }}
+
+  {{- /* in other cases, these variables are set in the "airflow.env" template */ -}}
+  {{- if not .Values.redis.enabled }}
+  {{- if not .Values.externalRedis.passwordSecret }}
+
+  ## credentials (from plain-text helm values)
+  REDIS_PASSWORD: {{ .Values.externalRedis.password | b64enc | quote }}
+  {{- end }}
   {{- end }}
 
   ## bash command which echos the URL encoded value of $REDIS_PASSWORD

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1620,11 +1620,27 @@ externalDatabase:
   ##
   database: airflow
 
-  ## the user of the external database
+  ## the username for the external database
   ##
   user: airflow
 
+  ## the name of a pre-created secret containing the external database user
+  ## - if set, this overrides `externalDatabase.user`
+  ##
+  userSecret: ""
+
+  ## the key within `externalDatabase.userSecret` containing the user string
+  ##
+  userSecretKey: "postgresql-user"
+
+  ## the password for the external database
+  ## - [WARNING] to avoid storing the password in plain-text within your values,
+  ##   create a Kubernetes secret and use `externalDatabase.passwordSecret`
+  ##
+  password: ""
+
   ## the name of a pre-created secret containing the external database password
+  ## - if set, this overrides `externalDatabase.password`
   ##
   passwordSecret: ""
 
@@ -1790,11 +1806,18 @@ externalRedis:
   ##
   port: 6379
 
-  ## the database number to use within the the external redis
+  ## the database number to use within the external redis
   ##
   databaseNumber: 1
 
+  ## the password for the external redis
+  ## - [WARNING] to avoid storing the password in plain-text within your values,
+  ##   create a Kubernetes secret and use `externalRedis.passwordSecret`
+  ##
+  password: ""
+
   ## the name of a pre-created secret containing the external redis password
+  ## - if set, this overrides `externalRedis.password`
   ##
   passwordSecret: ""
 


### PR DESCRIPTION
## What issues does your PR fix?

- resolves https://github.com/airflow-helm/charts/issues/511

## What does your PR do?

- Added values to set externalDatabase/externalRedis passwords directly with plain-text values:
   - `externalDatabase.password`
   - `externalRedis.password`
- Added values to set externalDatabase username from a secret:
   - `externalDatabase.userSecret`
   - `externalDatabase.userSecretKey` (default: `postgresql-user`)
- Added warning to NOTES.txt if user sets externalDatabase/externalRedis using the plain-text values.

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated