### PR TITLE
feat: add log-cleanup sidecar to scheduler/worker

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -900,6 +900,12 @@ workers:
   ## how many seconds (after the 9min) to wait before SIGKILL
   terminationPeriod: 60
 
+  logCleanup:
+    resources:
+      requests:
+        ## IMPORTANT! for autoscaling to work with logCleanup
+        memory: "64Mi"
+
 dags:
   gitSync:
     resources:
@@ -931,6 +937,16 @@ airflow:
     ## this does NOT give root permissions to Pods, only the "root" group
     fsGroup: 0
 
+scheduler:
+  logCleanup:
+    ## scheduler log-cleanup must be disabled if `logs.persistence.enabled` is `true`
+    enabled: false
+
+workers:
+  logCleanup:
+    ## workers log-cleanup must be disabled if `logs.persistence.enabled` is `true`
+    enabled: false
+
 logs:
   persistence:
     enabled: true
@@ -953,6 +969,16 @@ airflow:
     ## sets the filesystem owner group of files/folders in mounted volumes
     ## this does NOT give root permissions to Pods, only the "root" group
     fsGroup: 0
+
+scheduler:
+  logCleanup:
+    ## scheduler log-cleanup must be disabled if `logs.persistence.enabled` is `true`
+    enabled: false
+
+workers:
+  logCleanup:
+    ## workers log-cleanup must be disabled if `logs.persistence.enabled` is `true`
+    enabled: false
 
 logs:
   persistence:
@@ -1486,6 +1512,7 @@ Parameter | Description | Default
 `scheduler.podAnnotations` | Pod annotations for the scheduler Deployment | `{}`
 `scheduler.safeToEvict` | if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true" | `true`
 `scheduler.podDisruptionBudget.*` | configs for the PodDisruptionBudget of the scheduler | `<see values.yaml>`
+`scheduler.logCleanup.*` | configs for the log-cleanup sidecar of the scheduler | `<see values.yaml>`
 `scheduler.numRuns` | the value of the `airflow --num_runs` parameter used to run the airflow scheduler | `-1`
 `scheduler.extraPipPackages` | extra pip packages to install in the scheduler Pods | `[]`
 `scheduler.extraVolumeMounts` | extra VolumeMounts for the scheduler Pods | `[]`
@@ -1549,6 +1576,7 @@ Parameter | Description | Default
 `workers.autoscaling.*` | configs for the HorizontalPodAutoscaler of the worker Pods | `<see values.yaml>`
 `workers.celery.*` | configs for the celery worker Pods | `<see values.yaml>`
 `workers.terminationPeriod` | how many seconds to wait after SIGTERM before SIGKILL of the celery worker | `60`
+`workers.logCleanup.*` | configs for the log-cleanup sidecar of the worker Pods | `<see values.yaml>`
 `workers.extraPipPackages` | extra pip packages to install in the worker Pods | `[]`
 `workers.extraVolumeMounts` | extra VolumeMounts for the worker Pods | `[]`
 `workers.extraVolumes` | extra Volumes for the worker Pods | `[]`

--- a/charts/airflow/examples/google-gke/custom-values.yaml
+++ b/charts/airflow/examples/google-gke/custom-values.yaml
@@ -128,6 +128,27 @@ scheduler:
       cpu: "1000m"
       memory: "512Mi"
 
+  ## configs for the log-cleanup sidecar of the scheduler
+  ##
+  ## NOTE:
+  ## - helps prevent excessive log buildup by regularly deleting old files
+  ##
+  logCleanup:
+    ## if the log-cleanup sidecar is enabled
+    ##
+    enabled: true
+
+    ## resource requests/limits for the log-cleanup container
+    ##
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "32Mi"
+
+    ## the number of minutes to retain log files (by last-modified time)
+    ##
+    retentionMinutes: 21600
+
 ###################################
 # Airflow - WebUI Configs
 ###################################
@@ -245,6 +266,30 @@ workers:
   ##
   terminationPeriod: 60
 
+  ## configs for the log-cleanup sidecar of the worker Pods
+  ##
+  ## NOTE:
+  ## - helps prevent excessive log buildup by regularly deleting old files
+  ##
+  logCleanup:
+    ## if the log-cleanup sidecar is enabled
+    ##
+    enabled: true
+
+    ## resource requests/limits for the log-cleanup container
+    ##
+    ## WARNING:
+    ## - you MUST SPECIFY a resource request for logCleanup if using `workers.autoscaling`
+    ##
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "32Mi"
+
+    ## the number of minutes to retain log files (by last-modified time)
+    ##
+    retentionMinutes: 21600
+
 ###################################
 # Airflow - Flower Configs
 ###################################
@@ -291,6 +336,16 @@ dags:
     ##
     enabled: true
 
+    ## resource requests/limits for the git-sync container
+    ##
+    ## WARNING:
+    ## - you MUST SPECIFY a resource request for gitSync if using `workers.autoscaling`
+    ##
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "64Mi"
+
     ## the url of the git repo
     ##
     repo: "git@repo.example.com/my-airflow-dags.git"
@@ -314,15 +369,6 @@ dags:
     ## the key in `dags.gitSync.sshSecret` with your ssh-key file
     ##
     sshSecretKey: id_rsa
-
-    ## resource requests/limits for the git-sync container
-    ##
-    ## WARNING:
-    ## - you MUST SPECIFY a resource request for gitSync if using `workers.autoscaling`
-    ##
-    requests:
-      cpu: "50m"
-      memory: "64Mi"
 
 ###################################
 # Kubernetes - RBAC

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -66,6 +66,14 @@
   {{- if not (eq .Values.logs.persistence.accessMode "ReadWriteMany") }}
   {{ required "The `logs.persistence.accessMode` must be `ReadWriteMany`!" nil }}
   {{- end }}
+  {{- if .Values.scheduler.logCleanup.enabled }}
+  {{ required "If `logs.persistence.enabled=true`, then `scheduler.logCleanup.enabled` must be disabled!" nil }}
+  {{- end }}
+  {{- if .Values.workers.enabled }}
+    {{- if .Values.workers.logCleanup.enabled }}
+    {{ required "If `logs.persistence.enabled=true`, then `workers.logCleanup.enabled` must be disabled!" nil }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/* Checks for `dags.persistence` */}}

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -167,6 +167,12 @@ spec:
         {{- if .Values.dags.gitSync.enabled }}
         {{- include "airflow.container.git_sync" . | indent 8 }}
         {{- end }}
+        {{- if .Values.scheduler.logCleanup.enabled }}
+        {{- $lc_resources := .Values.scheduler.logCleanup.resources }}
+        {{- $lc_retention_min := .Values.scheduler.logCleanup.retentionMinutes }}
+        {{- $lc_interval_sec := .Values.scheduler.logCleanup.intervalSeconds }}
+        {{- include "airflow.container.log_cleanup" (dict "Release" .Release "Values" .Values "resources" $lc_resources "retention_min" $lc_retention_min "interval_sec" $lc_interval_sec) | indent 8 }}
+        {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -169,6 +169,12 @@ spec:
         {{- if .Values.dags.gitSync.enabled }}
         {{- include "airflow.container.git_sync" . | indent 8 }}
         {{- end }}
+        {{- if .Values.workers.logCleanup.enabled }}
+        {{- $lc_resources := .Values.workers.logCleanup.resources }}
+        {{- $lc_retention_min := .Values.workers.logCleanup.retentionMinutes }}
+        {{- $lc_interval_sec := .Values.workers.logCleanup.intervalSeconds }}
+        {{- include "airflow.container.log_cleanup" (dict "Release" .Release "Values" .Values "resources" $lc_resources "retention_min" $lc_retention_min "interval_sec" $lc_interval_sec) | indent 8 }}
+        {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}
         {{- end }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -521,6 +521,29 @@ scheduler:
     ##
     minAvailable: ""
 
+  ## configs for the log-cleanup sidecar of the scheduler
+  ## - helps prevent excessive log buildup by regularly deleting old files
+  ##
+  logCleanup:
+    ## if the log-cleanup sidecar is enabled
+    ## - [WARNING] must be disabled if `logs.persistence.enabled` is `true`
+    ##
+    enabled: true
+
+    ## resource requests/limits for the log-cleanup container
+    ## - spec of ResourceRequirements:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    ##
+    resources: {}
+
+    ## the number of minutes to retain log files (by last-modified time)
+    ##
+    retentionMinutes: 21600
+
+    ## the number of seconds between each check for files to delete
+    ##
+    intervalSeconds: 900
+
   ## sets `airflow --num_runs` parameter used to run the airflow scheduler
   ##
   numRuns: -1
@@ -793,6 +816,7 @@ workers:
 
   ## configs for the HorizontalPodAutoscaler of the worker Pods
   ## - [WARNING] if using git-sync, ensure `dags.gitSync.resources` is set
+  ## - [WARNING] if using worker log-cleanup, ensure `workers.logCleanup.resources` is set
   ##
   ## ____ EXAMPLE _______________
   ##   autoscaling:
@@ -836,6 +860,29 @@ workers:
   ##   to understand with KubernetesPodOperator(), as Pods may continue running
   ##
   terminationPeriod: 60
+
+  ## configs for the log-cleanup sidecar of the worker Pods
+  ## - helps prevent excessive log buildup by regularly deleting old files
+  ##
+  logCleanup:
+    ## if the log-cleanup sidecar is enabled
+    ## - [WARNING] must be disabled if `logs.persistence.enabled` is `true`
+    ##
+    enabled: true
+
+    ## resource requests/limits for the log-cleanup container
+    ## - spec of ResourceRequirements:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    ##
+    resources: {}
+
+    ## the number of minutes to retain log files (by last-modified time)
+    ##
+    retentionMinutes: 21600
+
+    ## the number of seconds between each check for files to delete
+    ##
+    intervalSeconds: 900
 
   ## extra pip packages to install in the worker Pod
   ##


### PR DESCRIPTION
## What issues does your PR fix?

- resolves https://github.com/airflow-helm/charts/issues/502

## What does your PR do?

- Adds a log-cleanup sidecar to the scheduler that automatically deletes old log files (by last-modified time)
- Adds the following new values:
   - `scheduler`
       - `scheduler.logCleanup.enabled` (default: `true`)
       - `scheduler.logCleanup.resources` (default: `{}`)
       - `scheduler.logCleanup.retentionMinutes` (default: `21600` = 15 days)
       - `scheduler.logCleanup.intervalSeconds` (default: `900` = 15 minutes)
   - `workers`
       - `workers.logCleanup.enabled` (default: `true`)
       - `workers.logCleanup.resources` (default: `{}`)
       - `workers.logCleanup.retentionMinutes` (default: `21600` = 15 days)
       - `workers.logCleanup.intervalSeconds` (default: `900` = 15 minutes)


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated