### PR TITLE
feat: add `airflow triggerer` Deployment

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1652,6 +1652,12 @@ workers:
   affinity: {}
   tolerations: []
 
+## airflow triggerer
+triggerer:
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
 ## airflow workers
 flower:
   nodeSelector: {}
@@ -1879,6 +1885,35 @@ Parameter | Description | Default
 `workers.extraPipPackages` | extra pip packages to install in the worker Pods | `[]`
 `workers.extraVolumeMounts` | extra VolumeMounts for the worker Pods | `[]`
 `workers.extraVolumes` | extra Volumes for the worker Pods | `[]`
+
+<hr>
+</details>
+
+### `triggerer.*`
+<details>
+<summary>Expand</summary>
+<hr>
+
+Parameter | Description | Default
+--- | --- | ---
+`triggerer.enabled` | if the triggerer should be deployed | `true`
+`triggerer.replicas` | the number of triggerer Pods to run | `1`
+`triggerer.resources` | resource requests/limits for the airflow triggerer Pods | `{}`
+`triggerer.nodeSelector` | the nodeSelector configs for the triggerer Pods | `{}`
+`triggerer.affinity` | the affinity configs for the triggerer Pods | `{}`
+`triggerer.tolerations` | the toleration configs for the triggerer Pods | `[]`
+`triggerer.securityContext` | the security context for the triggerer Pods | `{}`
+`triggerer.labels` | labels for the triggerer Deployment | `{}`
+`triggerer.podLabels` | Pod labels for the triggerer Deployment | `{}`
+`triggerer.annotations` | annotations for the triggerer Deployment | `{}`
+`triggerer.podAnnotations` | Pod annotations for the triggerer Deployment | `{}`
+`triggerer.safeToEvict` | if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true" | `true`
+`triggerer.podDisruptionBudget.*` | configs for the PodDisruptionBudget of the triggerer Deployment | `<see values.yaml>`
+`triggerer.capacity` | maximum number of triggers each triggerer will run at once (sets `AIRFLOW__TRIGGERER__DEFAULT_CAPACITY`) | 1000
+`triggerer.livenessProbe.*` | liveness probe for the triggerer Pods | `<see values.yaml>`
+`triggerer.extraPipPackages` | extra pip packages to install in the triggerer Pods | `[]`
+`triggerer.extraVolumeMounts` | extra VolumeMounts for the triggerer Pods | `[]`
+`triggerer.extraVolumes` | extra Volumes for the triggerer Pods | `[]`
 
 <hr>
 </details>

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -1909,7 +1909,7 @@ Parameter | Description | Default
 `triggerer.podAnnotations` | Pod annotations for the triggerer Deployment | `{}`
 `triggerer.safeToEvict` | if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true" | `true`
 `triggerer.podDisruptionBudget.*` | configs for the PodDisruptionBudget of the triggerer Deployment | `<see values.yaml>`
-`triggerer.capacity` | maximum number of triggers each triggerer will run at once (sets `AIRFLOW__TRIGGERER__DEFAULT_CAPACITY`) | 1000
+`triggerer.capacity` | maximum number of triggers each triggerer will run at once (sets `AIRFLOW__TRIGGERER__DEFAULT_CAPACITY`) | `1000`
 `triggerer.livenessProbe.*` | liveness probe for the triggerer Pods | `<see values.yaml>`
 `triggerer.extraPipPackages` | extra pip packages to install in the triggerer Pods | `[]`
 `triggerer.extraVolumeMounts` | extra VolumeMounts for the triggerer Pods | `[]`

--- a/charts/airflow/examples/google-gke/custom-values.yaml
+++ b/charts/airflow/examples/google-gke/custom-values.yaml
@@ -291,6 +291,33 @@ workers:
     retentionMinutes: 21600
 
 ###################################
+# Airflow - Triggerer Configs
+###################################
+triggerer:
+  ## if the airflow triggerer should be deployed
+  ##
+  ## WARNING:
+  ## - the triggerer component was added in airflow 2.2.0
+  ## - if `airflow.legacyCommands` is `true` the triggerer will NOT be deployed
+  ##
+  enabled: true
+
+  ## the number of triggerer Pods to run
+  ##
+  replicas: 1
+
+  ## resource requests/limits for the triggerer Pods
+  ##
+  resources:
+    requests:
+      cpu: "256m"
+      memory: "2Gi"
+
+  ## maximum number of triggers each triggerer will run at once (sets `AIRFLOW__TRIGGERER__DEFAULT_CAPACITY`)
+  ##
+  capacity: 1000
+
+###################################
 # Airflow - Flower Configs
 ###################################
 flower:

--- a/charts/airflow/examples/minikube/custom-values.yaml
+++ b/charts/airflow/examples/minikube/custom-values.yaml
@@ -96,6 +96,22 @@ workers:
   replicas: 1
 
 ###################################
+# Airflow - Triggerer Configs
+###################################
+triggerer:
+  ## if the airflow triggerer should be deployed
+  ##
+  ## WARNING:
+  ## - the triggerer component was added in airflow 2.2.0
+  ## - if `airflow.legacyCommands` is `true` the triggerer will NOT be deployed
+  ##
+  enabled: true
+
+  ## the number of triggerer Pods to run
+  ##
+  replicas: 1
+
+###################################
 # Airflow - Flower Configs
 ###################################
 flower:

--- a/charts/airflow/templates/_helpers/common.tpl
+++ b/charts/airflow/templates/_helpers/common.tpl
@@ -72,6 +72,17 @@ The path containing DAG files
 {{- end -}}
 
 {{/*
+If the airflow triggerer should be used.
+*/}}
+{{- define "airflow.triggerer.should_use" -}}
+{{- if .Values.triggerer.enabled -}}
+{{- if not .Values.airflow.legacyCommands -}}
+true
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 If PgBouncer should be used.
 */}}
 {{- define "airflow.pgbouncer.should_use" -}}

--- a/charts/airflow/templates/_helpers/common.tpl
+++ b/charts/airflow/templates/_helpers/common.tpl
@@ -6,7 +6,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-
 {{/*
 The version of airflow being deployed.
 - extracted from the image tag (only for images in airflow's official DockerHub repo)

--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -139,7 +139,7 @@ data:
   ## ================
   ## Airflow Configs (Triggerer)
   ## ================
-  {{- if and .Values.triggerer.enabled (not .Values.airflow.legacyCommands) }}
+  {{- if include "airflow.triggerer.should_use" . }}
   AIRFLOW__TRIGGERER__DEFAULT_CAPACITY: {{ .Values.triggerer.capacity | toString | b64enc | quote }}
   {{- end }}
 

--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -140,7 +140,9 @@ data:
   ## Airflow Configs (Triggerer)
   ## ================
   {{- if include "airflow.triggerer.should_use" . }}
+  {{- if not .Values.airflow.config.AIRFLOW__TRIGGERER__DEFAULT_CAPACITY }}
   AIRFLOW__TRIGGERER__DEFAULT_CAPACITY: {{ .Values.triggerer.capacity | toString | b64enc | quote }}
+  {{- end }}
   {{- end }}
 
   ## ================

--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -137,6 +137,13 @@ data:
   {{- end }}
 
   ## ================
+  ## Airflow Configs (Triggerer)
+  ## ================
+  {{- if and .Values.triggerer.enabled (not .Values.airflow.legacyCommands) }}
+  AIRFLOW__TRIGGERER__DEFAULT_CAPACITY: {{ .Values.triggerer.capacity | toString | b64enc | quote }}
+  {{- end }}
+
+  ## ================
   ## Airflow Configs (Logging)
   ## ================
   {{- if .Values.airflow.legacyCommands }}

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -1,0 +1,145 @@
+{{- if and .Values.triggerer.enabled (not .Values.airflow.legacyCommands) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.triggerer.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.triggerer.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.triggerer.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.triggerer.securityContext) }}
+{{- $extraPipPackages := concat .Values.airflow.extraPipPackages .Values.triggerer.extraPipPackages }}
+{{- $extraVolumeMounts := .Values.triggerer.extraVolumeMounts }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $extraVolumes := .Values.triggerer.extraVolumes }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "airflow.fullname" . }}-triggerer
+  {{- if .Values.triggerer.annotations }}
+  annotations:
+    {{- toYaml .Values.triggerer.annotations | nindent 4 }}
+  {{- end }}
+  labels:
+    app: {{ include "airflow.labels.app" . }}
+    component: triggerer
+    chart: {{ include "airflow.labels.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.triggerer.labels }}
+    {{- toYaml .Values.triggerer.labels | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.triggerer.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      ## multiple triggerer pods can safely run concurrently
+      maxSurge: 25%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: {{ include "airflow.labels.app" . }}
+      component: triggerer
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/secret-config-envs: {{ include (print $.Template.BasePath "/config/secret-config-envs.yaml") . | sha256sum }}
+        checksum/secret-local-settings: {{ include (print $.Template.BasePath "/config/secret-local-settings.yaml") . | sha256sum }}
+        {{- if .Values.airflow.podAnnotations }}
+        {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.triggerer.podAnnotations }}
+        {{- toYaml .Values.triggerer.podAnnotations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.triggerer.safeToEvict }}
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        {{- end }}
+      labels:
+        app: {{ include "airflow.labels.app" . }}
+        component: triggerer
+        release: {{ .Release.Name }}
+        {{- if .Values.triggerer.podLabels }}
+        {{- toYaml .Values.triggerer.podLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      restartPolicy: Always
+      {{- if .Values.airflow.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.airflow.image.pullSecret }}
+      {{- end }}
+      {{- if $podNodeSelector }}
+      nodeSelector:
+        {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podAffinity }}
+      affinity:
+        {{- $podAffinity | nindent 8 }}
+      {{- end }}
+      {{- if $podTolerations }}
+      tolerations:
+        {{- $podTolerations | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "airflow.serviceAccountName" . }}
+      {{- if $podSecurityContext }}
+      securityContext:
+        {{- $podSecurityContext | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- if $extraPipPackages }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- end }}
+        {{- if .Values.dags.gitSync.enabled }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+      containers:
+        - name: airflow-triggerer
+          {{- include "airflow.image" . | indent 10 }}
+          resources:
+            {{- toYaml .Values.triggerer.resources | nindent 12 }}
+          envFrom:
+            {{- include "airflow.envFrom" . | indent 12 }}
+          env:
+            {{- include "airflow.env" . | indent 12 }}
+          command:
+            {{- include "airflow.command" . | indent 12 }}
+          args:
+            - "bash"
+            - "-c"
+            - "exec airflow triggerer"
+          {{- if .Values.triggerer.livenessProbe.enabled }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.triggerer.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.triggerer.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.triggerer.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.triggerer.livenessProbe.failureThreshold }}
+            exec:
+              command:
+                - "python"
+                - "-Wignore"
+                - "-c"
+                - |
+                  import os
+                  from airflow.jobs.triggerer_job import TriggererJob
+                  from airflow.utils.db import create_session
+                  from airflow.utils.net import get_hostname
+                  import sys
+                  with create_session() as session:
+                      job = session.query(TriggererJob).filter_by(hostname=get_hostname()).order_by(
+                          TriggererJob.latest_heartbeat.desc()).limit(1).first()
+                  sys.exit(0 if job.is_alive() else 1)
+          {{- end }}
+          {{- if $volumeMounts }}
+          volumeMounts:
+            {{- $volumeMounts | indent 12 }}
+          {{- end }}
+        {{- if .Values.dags.gitSync.enabled }}
+        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- end }}
+        {{- if .Values.airflow.extraContainers }}
+        {{- toYaml .Values.airflow.extraContainers | nindent 8 }}
+        {{- end }}
+      {{- if $volumes }}
+      volumes:
+        {{- $volumes | indent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -114,19 +114,34 @@ spec:
             failureThreshold: {{ .Values.triggerer.livenessProbe.failureThreshold }}
             exec:
               command:
+                {{- include "airflow.command" . | indent 16 }}
                 - "python"
                 - "-Wignore"
                 - "-c"
                 - |
                   import os
+                  import sys
+
+                  # suppress logs triggered from importing airflow packages
+                  os.environ["AIRFLOW__LOGGING__LOGGING_LEVEL"] = "ERROR"
+
                   from airflow.jobs.triggerer_job import TriggererJob
                   from airflow.utils.db import create_session
                   from airflow.utils.net import get_hostname
-                  import sys
+
                   with create_session() as session:
-                      job = session.query(TriggererJob).filter_by(hostname=get_hostname()).order_by(
-                          TriggererJob.latest_heartbeat.desc()).limit(1).first()
-                  sys.exit(0 if job.is_alive() else 1)
+                      # ensure the TriggererJob with most recent heartbeat for this `hostname` is alive
+                      hostname = get_hostname()
+                      triggerer_job = session \
+                          .query(TriggererJob) \
+                          .filter_by(hostname=hostname) \
+                          .order_by(TriggererJob.latest_heartbeat.desc()) \
+                          .limit(1) \
+                          .first()
+                      if (triggerer_job is not None) and triggerer_job.is_alive():
+                          pass
+                      else:
+                          sys.exit(f"The TriggererJob (id={triggerer_job.id}) for hostname '{hostname}' is not alive")
           {{- end }}
           {{- if $volumeMounts }}
           volumeMounts:

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.triggerer.enabled (not .Values.airflow.legacyCommands) }}
+{{- if include "airflow.triggerer.should_use" . }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.triggerer.nodeSelector) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.triggerer.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.triggerer.tolerations) }}

--- a/charts/airflow/templates/triggerer/triggerer-pdb.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-pdb.yaml
@@ -1,0 +1,24 @@
+{{- if and (.Values.triggerer.enabled) (.Values.triggerer.podDisruptionBudget.enabled) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "airflow.fullname" . }}-triggerer
+  labels:
+    app: {{ include "airflow.labels.app" . }}
+    component: triggerer
+    chart: {{ include "airflow.labels.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  {{- if .Values.triggerer.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.triggerer.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- if .Values.triggerer.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.triggerer.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ include "airflow.labels.app" . }}
+      component: triggerer
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/airflow/templates/triggerer/triggerer-pdb.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.triggerer.enabled) (.Values.triggerer.podDisruptionBudget.enabled) }}
+{{- if and (include "airflow.triggerer.should_use" .) (.Values.triggerer.podDisruptionBudget.enabled) }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -965,6 +965,119 @@ workers:
   extraVolumes: []
 
 ###################################
+## COMPONENT | Triggerer
+###################################
+triggerer:
+  ## if the airflow triggerer should be deployed
+  ## - [WARNING] the triggerer component was added in airflow 2.2.0
+  ## - [WARNING] if `airflow.legacyCommands` is `true` the triggerer will NOT be deployed
+  ##
+  enabled: true
+
+  ## the number of triggerer Pods to run
+  ## - if you set this >1 we recommend defining a `triggerer.podDisruptionBudget`
+  ##
+  replicas: 1
+
+  ## resource requests/limits for the triggerer Pods
+  ## - spec for ResourceRequirements:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+  ##
+  resources: {}
+
+  ## the nodeSelector configs for the triggerer Pods
+  ## - docs for nodeSelector:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  ##
+  nodeSelector: {}
+
+  ## the affinity configs for the triggerer Pods
+  ## - spec for Affinity:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
+  ##
+  affinity: {}
+
+  ## the toleration configs for the triggerer Pods
+  ## - spec for Toleration:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
+  ##
+  tolerations: []
+
+  ## the security context for the triggerer Pods
+  ## - spec for PodSecurityContext:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#podsecuritycontext-v1-core
+  ##
+  securityContext: {}
+
+  ## labels for the triggerer Deployment
+  ##
+  labels: {}
+
+  ## Pod labels for the triggerer Deployment
+  ##
+  podLabels: {}
+
+  ## annotations for the triggerer Deployment
+  ##
+  annotations: {}
+
+  ## Pod annotations for the triggerer Deployment
+  ##
+  podAnnotations: {}
+
+  ## if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true"
+  ##
+  safeToEvict: true
+
+  ## configs for the PodDisruptionBudget of the triggerer Deployment
+  ##
+  podDisruptionBudget:
+    ## if a PodDisruptionBudget resource is created for the triggerer Deployment
+    ##
+    enabled: false
+
+    ## the maximum unavailable pods/percentage for the triggerer Deployment
+    ##
+    maxUnavailable: ""
+
+    ## the minimum available pods/percentage for the triggerer Deployment
+    ##
+    minAvailable: ""
+
+  ## maximum number of triggers each triggerer will run at once (sets `AIRFLOW__TRIGGERER__DEFAULT_CAPACITY`)
+  ##
+  capacity: 1000
+
+  ## configs for the triggerer Pods' liveness probe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 60
+    failureThreshold: 5
+
+  ## extra pip packages to install in the triggerer Pod
+  ##
+  ## ____ EXAMPLE _______________
+  ##   extraPipPackages:
+  ##     - "SomeProject==1.0.0"
+  ##
+  extraPipPackages: []
+
+  ## extra VolumeMounts for the triggerer Pods
+  ## - spec for VolumeMount:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core
+  ##
+  extraVolumeMounts: []
+
+  ## extra Volumes for the triggerer Pods
+  ## - spec for Volume:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volume-v1-core
+  ##
+  extraVolumes: []
+
+###################################
 ## COMPONENT | Flower
 ###################################
 flower:


### PR DESCRIPTION
## What issues does your PR fix?

- resolves https://github.com/airflow-helm/charts/issues/424
- supersedes & closes https://github.com/airflow-helm/charts/pull/521
   - _(some further changes were needed, and I did not have write access to that repo)_


## What does your PR do?

- Adds a new Deployment for the [`airflow triggerer`](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html#triggerer) so we fully support Airflow's [Deferrable Tasks](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html) feature.
   - ___WARNING:__ `airflow triggerer` was added in airflow `2.2.0`, so will crash-loop if enabled in previous versions_
   - ___NOTE:__ The triggerer deployment is automatically (and silently) disabled in the following situations:_
       - _if `airflow.legacyCommands` is `true`_
       - _if `airflow.image.repository` is `apache/airflow` and `airflow.image.tag` corresponds to an airflow version before `2.2.0`_
- Adds the following new values:
   - `triggerer.enabled` (default: `true`)
   - `triggerer.replicas` (default : `1`)
   - `triggerer.resources`
   - `triggerer.nodeSelector`
   - `triggerer.affinity`
   - `triggerer.tolerations`
   - `triggerer.securityContext`
   - `triggerer.labels`
   - `triggerer.podLabels`
   - `triggerer.annotations`
   - `triggerer.podAnnotations`
   - `triggerer.safeToEvict` (default: `true`)
   - `triggerer.podDisruptionBudget`:
       - `triggerer.podDisruptionBudget.enabled` (default: `false`)
       - `triggerer.podDisruptionBudget.maxUnavailable`
       - `triggerer.podDisruptionBudget.minAvailable`
   - `triggerer.capacity` (default: `1000`)
   - `triggerer.livenessProbe`:
       - `triggerer.livenessProbe.enabled` (default: `true`)
       - `triggerer.livenessProbe.initialDelaySeconds` (default: `10`)
       - `triggerer.livenessProbe.periodSeconds` (default: `30`)
       - `triggerer.livenessProbe.timeoutSeconds` (default: `60`)
       - `triggerer.livenessProbe.failureThreshold` (default: `5`)
   - `triggerer.extraPipPackages`
   - `triggerer.extraVolumeMounts`
   - `triggerer.extraVolumes`


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated