### PR TITLE
fix: cast user values with toString before b64enc

### DIFF
--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -25,16 +25,16 @@ data:
   DATABASE_HOST: {{ printf "%s.%s.svc.%s" (include "airflow.postgresql.fullname" .) (.Release.Namespace) (.Values.airflow.clusterDomain) | b64enc | quote }}
   DATABASE_PORT: {{ "5432" | b64enc | quote }}
   {{- else }}
-  DATABASE_HOST: {{ .Values.externalDatabase.host | b64enc | quote }}
+  DATABASE_HOST: {{ .Values.externalDatabase.host | toString | b64enc | quote }}
   DATABASE_PORT: {{ .Values.externalDatabase.port | toString | b64enc | quote }}
   {{- end }}
 
   ## database configs
   {{- if .Values.postgresql.enabled }}
-  DATABASE_DB: {{ .Values.postgresql.postgresqlDatabase | b64enc | quote }}
+  DATABASE_DB: {{ .Values.postgresql.postgresqlDatabase | toString | b64enc | quote }}
   {{- else }}
-  DATABASE_DB: {{ .Values.externalDatabase.database | b64enc | quote }}
-  DATABASE_PROPERTIES: {{ .Values.externalDatabase.properties | b64enc | quote }}
+  DATABASE_DB: {{ .Values.externalDatabase.database | toString | b64enc | quote }}
+  DATABASE_PROPERTIES: {{ .Values.externalDatabase.properties | toString | b64enc | quote }}
   {{- end }}
 
   {{- /* in other cases, these variables are set in the "airflow.env" template */ -}}
@@ -43,10 +43,10 @@ data:
 
   ## database credentials (from plain-text helm values)
   {{- if not .Values.externalDatabase.userSecret }}
-  DATABASE_USER: {{ .Values.externalDatabase.user | b64enc | quote }}
+  DATABASE_USER: {{ .Values.externalDatabase.user | toString | b64enc | quote }}
   {{- end }}
   {{- if not .Values.externalDatabase.passwordSecret }}
-  DATABASE_PASSWORD: {{ .Values.externalDatabase.password | b64enc | quote }}
+  DATABASE_PASSWORD: {{ .Values.externalDatabase.password | toString | b64enc | quote }}
   {{- end }}
   {{- end }}
   {{- end }}
@@ -88,10 +88,10 @@ data:
   REDIS_PORT: {{ "6379" | b64enc | quote }}
   REDIS_DBNUM: {{ "1" | b64enc | quote }}
   {{- else }}
-  REDIS_HOST: {{ .Values.externalRedis.host | b64enc | quote }}
+  REDIS_HOST: {{ .Values.externalRedis.host | toString | b64enc | quote }}
   REDIS_PORT: {{ .Values.externalRedis.port | toString | b64enc | quote }}
   REDIS_DBNUM: {{ .Values.externalRedis.databaseNumber | toString | b64enc | quote }}
-  REDIS_PROPERTIES: {{.Values.externalRedis.properties | b64enc | quote }}
+  REDIS_PROPERTIES: {{.Values.externalRedis.properties | toString | b64enc | quote }}
   {{- end }}
 
   {{- /* in other cases, these variables are set in the "airflow.env" template */ -}}
@@ -99,7 +99,7 @@ data:
   {{- if not .Values.externalRedis.passwordSecret }}
 
   ## credentials (from plain-text helm values)
-  REDIS_PASSWORD: {{ .Values.externalRedis.password | b64enc | quote }}
+  REDIS_PASSWORD: {{ .Values.externalRedis.password | toString | b64enc | quote }}
   {{- end }}
   {{- end }}
 
@@ -115,13 +115,13 @@ data:
   ## Airflow Configs (General)
   ## ================
   AIRFLOW__CORE__DAGS_FOLDER: {{ include "airflow.dags.path" . | b64enc | quote }}
-  AIRFLOW__CORE__EXECUTOR: {{ .Values.airflow.executor | b64enc | quote }}
+  AIRFLOW__CORE__EXECUTOR: {{ .Values.airflow.executor | toString | b64enc | quote }}
   {{- if .Values.airflow.fernetKey }}
-  AIRFLOW__CORE__FERNET_KEY: {{ .Values.airflow.fernetKey | b64enc | quote }}
+  AIRFLOW__CORE__FERNET_KEY: {{ .Values.airflow.fernetKey | toString | b64enc | quote }}
   {{- end }}
   AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD: {{ `bash -c 'eval "$DATABASE_SQLALCHEMY_CMD"'` | b64enc | quote }}
   {{- if .Values.airflow.webserverSecretKey }}
-  AIRFLOW__WEBSERVER__SECRET_KEY: {{ .Values.airflow.webserverSecretKey | b64enc | quote }}
+  AIRFLOW__WEBSERVER__SECRET_KEY: {{ .Values.airflow.webserverSecretKey | toString | b64enc | quote }}
   {{- end }}
   AIRFLOW__WEBSERVER__WEB_SERVER_PORT: {{ "8080" | b64enc | quote }}
   AIRFLOW__CELERY__FLOWER_PORT: {{ "5555" | b64enc | quote }}
@@ -149,10 +149,10 @@ data:
   ## Airflow Configs (Logging)
   ## ================
   {{- if .Values.airflow.legacyCommands }}
-  AIRFLOW__CORE__BASE_LOG_FOLDER: {{ .Values.logs.path | b64enc | quote }}
+  AIRFLOW__CORE__BASE_LOG_FOLDER: {{ .Values.logs.path | toString | b64enc | quote }}
   AIRFLOW__CORE__DAG_PROCESSOR_MANAGER_LOG_LOCATION: {{ printf "%s/dag_processor_manager/dag_processor_manager.log" .Values.logs.path | b64enc | quote }}
   {{- else }}
-  AIRFLOW__LOGGING__BASE_LOG_FOLDER: {{ .Values.logs.path | b64enc | quote }}
+  AIRFLOW__LOGGING__BASE_LOG_FOLDER: {{ .Values.logs.path | toString | b64enc | quote }}
   AIRFLOW__LOGGING__DAG_PROCESSOR_MANAGER_LOG_LOCATION: {{ printf "%s/dag_processor_manager/dag_processor_manager.log" .Values.logs.path | b64enc | quote }}
   {{- end }}
   AIRFLOW__SCHEDULER__CHILD_PROCESS_LOG_DIRECTORY: {{ printf "%s/scheduler" .Values.logs.path | b64enc | quote }}
@@ -171,13 +171,13 @@ data:
   ## ================
   {{- if include "airflow.executor.kubernetes_like" . }}
   {{- if not .Values.airflow.config.AIRFLOW__KUBERNETES__NAMESPACE }}
-  AIRFLOW__KUBERNETES__NAMESPACE: {{ .Release.Namespace | b64enc | quote }}
+  AIRFLOW__KUBERNETES__NAMESPACE: {{ .Release.Namespace | toString | b64enc | quote }}
   {{- end }}
   {{- if not .Values.airflow.config.AIRFLOW__KUBERNETES__WORKER_CONTAINER_REPOSITORY }}
-  AIRFLOW__KUBERNETES__WORKER_CONTAINER_REPOSITORY: {{ .Values.airflow.image.repository | b64enc | quote }}
+  AIRFLOW__KUBERNETES__WORKER_CONTAINER_REPOSITORY: {{ .Values.airflow.image.repository | toString | b64enc | quote }}
   {{- end }}
   {{- if not .Values.airflow.config.AIRFLOW__KUBERNETES__WORKER_CONTAINER_TAG }}
-  AIRFLOW__KUBERNETES__WORKER_CONTAINER_TAG: {{ .Values.airflow.image.tag | b64enc | quote }}
+  AIRFLOW__KUBERNETES__WORKER_CONTAINER_TAG: {{ .Values.airflow.image.tag | toString | b64enc | quote }}
   {{- end }}
   {{- if not .Values.airflow.config.AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE }}
   AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE: {{ "/opt/airflow/pod_templates/pod_template.yaml" | b64enc | quote }}


### PR DESCRIPTION
## What issues does your PR fix?

- N/A

## What does your PR do?

- Cast user-provided values with `toString` before passing to `b64enc`, preventing helm syntax errors if int-type values are passed when strings are expected.
    - ___NOTE:__ this is most likely to affect user/password values, as number-only values are possible:_
       - `externalDatabase.user`
       - `externalDatabase.password`
       - `externalRedis.password`

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated