### PR TITLE
fix: pgbouncer liveness probe in minikube

### DIFF
--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -75,8 +75,12 @@ data:
   DATABASE_CELERY_CMD: {{ `echo -n "db+mysql://$(eval $DATABASE_USER_CMD):$(eval $DATABASE_PASSWORD_CMD)@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DB}${DATABASE_PROPERTIES}"` | b64enc | quote }}
   {{- end }}
 
+  {{- if include "airflow.pgbouncer.should_use" . }}
   ## bash command which echos the DB connection string in `psql` cli format
-  DATABASE_PSQL_CMD: {{ `echo -n "postgresql://$(eval $DATABASE_USER_CMD):$(eval $DATABASE_PASSWORD_CMD)@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DB}${DATABASE_PROPERTIES}"` | b64enc | quote }}
+  ## NOTE: uses `127.0.0.1` as the host because this is only used in the pgbouncer liveness probe
+  ##       and minikube does not allow pods to access their own `cluster.local` service so would otherwise fail
+  DATABASE_PSQL_CMD: {{ `echo -n "postgresql://$(eval $DATABASE_USER_CMD):$(eval $DATABASE_PASSWORD_CMD)@127.0.0.1:${DATABASE_PORT}/${DATABASE_DB}${DATABASE_PROPERTIES}"` | b64enc | quote }}
+  {{- end }}
 
   ## ================
   ## Redis Configs


### PR DESCRIPTION
## What issues does your PR fix?

- fixes https://github.com/airflow-helm/charts/issues/558


## What does your PR do?

- Changes the PgBouncer liveness probe to use `172.0.0.1` rather than `airflow-pgbouncer.airflow.svc.cluster.local`
   - ___NOTE:__ this is necessary because minikube does not allow Pods to access their own `cluster.local` services https://github.com/kubernetes/minikube/issues/1568_


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated