### PR TITLE
fix: wait-for-db-migrations in airflow 2.3.0

### DIFF
--- a/charts/airflow/templates/db-migrations/_helpers/code.tpl
+++ b/charts/airflow/templates/db-migrations/_helpers/code.tpl
@@ -82,7 +82,7 @@ def needs_db_migrations() -> bool:
     log_alembic_level = log_alembic.level
     try:
         log_alembic.setLevel("WARN")
-        check_migrations(0)
+        check_migrations(1)
         log_alembic.setLevel(log_alembic_level)
         return False
     except TimeoutError:


### PR DESCRIPTION
## What issues does your PR fix?

- related to https://github.com/airflow-helm/charts/issues/572

## What does your PR do?

- Fixes an issue due to a breaking change in Airflow 2.3.0 where the db-migration logic always thinks there are pending migrations if `timeout=0`.
    - [Old loop for Airflow 2.2.5](https://github.com/apache/airflow/blob/2.2.5/airflow/utils/db.py#L638)
    - [New loop for Airflow 2.3.0](https://github.com/apache/airflow/blob/2.3.0/airflow/utils/db.py#L696)
- This change should be backward-compatible with pre-Airflow 2.3.0 as well, it'll just loop one more time.


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated