### PR TITLE
feat: allow using extraVolumeMounts for log storage

### DIFF
--- a/charts/airflow/docs/faq/monitoring/log-persistence.md
+++ b/charts/airflow/docs/faq/monitoring/log-persistence.md
@@ -216,12 +216,12 @@ Kubernetes has many types of Pod Volumes, consult [the official docs](https://ku
 
 > 🟥 __Warning__ 🟥
 >
-> This is an advanced feature, only use it if you know that you need it.
+> Pod Volumes are an advanced feature, consider other options unless you need the flexibility of this approach.
 
 > 🟦 __Tip__ 🟦
 >
 > It is possible to store both __logs__ AND __DAGs__ on the same Pod Volume by setting `dags.path` and `logs.path` to be a sub folder 
-> under the `mountPath` of your `airflow.extraVolumeMounts`. _(WARNING: the volume type must support writing)_
+> under a `mountPath` from `airflow.extraVolumeMounts`. _(WARNING: the volume type must support writing)_
 
 <details>
 <summary>
@@ -233,9 +233,8 @@ Kubernetes has many types of Pod Volumes, consult [the official docs](https://ku
 
 > 🟦 __Tip__ 🟦
 >
-> The chart has special values just for PersistentVolumeClaims (`logs.persistence.*`).
-> <br>
-> Unless you require the flexibility of `extraVolumeMounts`, we recommend using [`Option 1`](#option-1---persistent-volume-claim) instead.
+> The chart has special values just for PersistentVolumeClaims (`logs.persistence.*`), 
+> see [`Option 1`](#option-1---persistent-volume-claim) for more information.
 
 For example, to mount a [`persistentVolumeClaim`](https://kubernetes.io/docs/concepts/storage/volumes/#persistentvolumeclaim) type volume at `/opt/airflow/logs`:
 

--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -6,7 +6,7 @@
 {{- $extraVolumeMounts := .Values.airflow.kubernetesPodTemplate.extraVolumeMounts }}
 {{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
 {{- $extraVolumes := .Values.airflow.kubernetesPodTemplate.extraVolumes }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/airflow/templates/NOTES.txt
+++ b/charts/airflow/templates/NOTES.txt
@@ -12,6 +12,22 @@
   {{- end }}
 {{- end }}
 
+{{- /* if an extra volume has been mounted for worker logs */ -}}
+{{- $extra_volumes_worker_logs := false }}
+{{- if include "airflow.extraVolumeMounts.has_log_path" . }}
+{{- $extra_volumes_worker_logs = true }}
+{{- end }}
+{{- if .Values.workers.enabled }}
+  {{- if include "airflow._has_logs_path" (dict "Values" .Values "volume_mounts" .Values.workers.extraVolumeMounts) }}
+  {{- $extra_volumes_worker_logs = true }}
+  {{- end }}
+{{- end }}
+{{- if and (include "airflow.executor.kubernetes_like" .) (not .Values.airflow.kubernetesPodTemplate.stringOverride) }}
+  {{- if include "airflow._has_logs_path" (dict "Values" .Values "volume_mounts" .Values.airflow.kubernetesPodTemplate.extraVolumeMounts) }}
+  {{- $extra_volumes_worker_logs = true }}
+  {{- end }}
+{{- end }}
+
 {{- /* if we show the fernet_key warning */ -}}
 {{- $fernet_key_warning := true }}
 {{- $fernet_key_envvars := list "AIRFLOW__CORE__FERNET_KEY" "AIRFLOW__CORE__FERNET_KEY_CMD" "AIRFLOW__CORE__FERNET_KEY_SECRET" }}
@@ -118,9 +134,9 @@ Default Airflow Webserver login:
 {{- end }}
 {{ end }}
 
-{{- if and (not .Values.logs.persistence.enabled) (not $remote_logging_enabled) }}
+{{- if not (or .Values.logs.persistence.enabled $remote_logging_enabled $extra_volumes_worker_logs) }}
 You have NOT set up persistence for worker task logs, do this by:
-  1. Using a Kubernetes PVC with `logs.persistence.*`
+  1. Using a PersistentVolumeClaim with `logs.persistence.*`
   2. Using remote logging with `AIRFLOW__LOGGING__REMOTE_LOGGING`
 {{ end }}
 

--- a/charts/airflow/templates/_helpers/common.tpl
+++ b/charts/airflow/templates/_helpers/common.tpl
@@ -84,6 +84,46 @@ The path containing DAG files
 {{- end -}}
 
 {{/*
+Helper template which checks if `logs.path` is stored under any of the passed `volumeMounts`.
+EXAMPLE USAGE: {{ include "airflow._has_logs_path" (dict "Values" .Values "volume_mounts" .Values.xxxx.extraVolumeMounts) }}
+*/}}
+{{- define "airflow._has_logs_path" -}}
+{{- $has_logs_path := false -}}
+{{- /* loop over `.volume_mounts`, checking if `mountPath` is a prefix of `logs.path` */ -}}
+{{- range .volume_mounts -}}
+  {{- if .mountPath }}
+    {{- if hasPrefix (clean .mountPath) (clean $.Values.logs.path) -}}
+    {{- $has_logs_path = true -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if $has_logs_path -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+If `logs.path` is stored under any of the global `airflow.extraVolumeMounts` mounts.
+*/}}
+{{- define "airflow.extraVolumeMounts.has_log_path" -}}
+{{- include "airflow._has_logs_path" (dict "Values" .Values "volume_mounts" .Values.airflow.extraVolumeMounts) -}}
+{{- end -}}
+
+{{/*
+If `logs.path` is stored under any of the `scheduler.extraVolumeMounts` mounts.
+*/}}
+{{- define "airflow.scheduler.extraVolumeMounts.has_log_path" -}}
+{{- include "airflow._has_logs_path" (dict "Values" .Values "volume_mounts" .Values.scheduler.extraVolumeMounts) -}}
+{{- end -}}
+
+{{/*
+If `logs.path` is stored under any of the `workers.extraVolumeMounts` mounts.
+*/}}
+{{- define "airflow.workers.extraVolumeMounts.has_log_path" -}}
+{{- include "airflow._has_logs_path" (dict "Values" .Values "volume_mounts" .Values.workers.extraVolumeMounts) -}}
+{{- end -}}
+
+{{/*
 If the airflow triggerer should be used.
 */}}
 {{- define "airflow.triggerer.should_use" -}}

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -363,7 +363,11 @@ EXAMPLE USAGE: {{ include "airflow.volumeMounts" (dict "Release" .Release "Value
 {{- end }}
 
 {{- /* logs */ -}}
-{{- if .Values.logs.persistence.enabled }}
+{{- if include "airflow.extraVolumeMounts.has_log_path" . }}
+{{- /* when `airflow.extraVolumeMounts` has `logs.path`, we dont need a "logs-data" volume mount */ -}}
+{{- else if include "airflow._has_logs_path" (dict "Values" .Values "volume_mounts" .extraVolumeMounts) }}
+{{- /* when `.extraVolumeMounts` has `logs.path`, we dont need a "logs-data" volume mount */ -}}
+{{- else if .Values.logs.persistence.enabled }}
 - name: logs-data
   mountPath: {{ .Values.logs.path }}
   subPath: {{ .Values.logs.persistence.subPath }}
@@ -391,7 +395,7 @@ EXAMPLE USAGE: {{ include "airflow.volumeMounts" (dict "Release" .Release "Value
 
 {{/*
 The list of `volumes` for web/scheduler/worker/flower Pods
-EXAMPLE USAGE: {{ include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
+EXAMPLE USAGE: {{ include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 */}}
 {{- define "airflow.volumes" }}
 {{- /* airflow_local_settings.py */ -}}
@@ -421,7 +425,11 @@ EXAMPLE USAGE: {{ include "airflow.volumes" (dict "Release" .Release "Values" .V
 {{- end }}
 
 {{- /* logs */ -}}
-{{- if .Values.logs.persistence.enabled }}
+{{- if include "airflow.extraVolumeMounts.has_log_path" . }}
+{{- /* when `airflow.extraVolumeMounts` has `logs.path`, we dont need a "logs-data" volume */ -}}
+{{- else if include "airflow._has_logs_path" (dict "Values" .Values "volume_mounts" .extraVolumeMounts) }}
+{{- /* when `.extraVolumeMounts` has `logs.path`, we dont need a "logs-data" volume */ -}}
+{{- else if .Values.logs.persistence.enabled }}
 - name: logs-data
   persistentVolumeClaim:
     {{- if .Values.logs.persistence.existingClaim }}

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -61,18 +61,41 @@
   {{ required "Don't define `airflow.config.AIRFLOW__CORE__SQL_ALCHEMY_CONN`, it will be automatically set by the chart!" nil }}
 {{- end }}
 
+{{/* Checks for `scheduler.logCleanup` */}}
+{{- if .Values.scheduler.logCleanup.enabled }}
+  {{- if .Values.logs.persistence.enabled }}
+  {{ required "If `logs.persistence.enabled=true`, then `scheduler.logCleanup.enabled` must be `false`!" nil }}
+  {{- end }}
+  {{- if include "airflow.extraVolumeMounts.has_log_path" . }}
+  {{ required "If `logs.path` is under any `airflow.extraVolumeMounts`, then `scheduler.logCleanup.enabled` must be `false`!" nil }}
+  {{- end }}
+  {{- if include "airflow.scheduler.extraVolumeMounts.has_log_path" . }}
+  {{ required "If `logs.path` is under any `scheduler.extraVolumeMounts`, then `scheduler.logCleanup.enabled` must be `false`!" nil }}
+  {{- end }}
+{{- end }}
+
+{{/* Checks for `workers.logCleanup` */}}
+{{- if .Values.workers.enabled }}
+  {{- if .Values.workers.logCleanup.enabled }}
+    {{- if .Values.logs.persistence.enabled }}
+    {{ required "If `logs.persistence.enabled=true`, then `workers.logCleanup.enabled` must be `false`!" nil }}
+    {{- end }}
+    {{- if include "airflow.extraVolumeMounts.has_log_path" . }}
+    {{ required "If `logs.path` is under any `airflow.extraVolumeMounts`, then `workers.logCleanup.enabled` must be `false`!" nil }}
+    {{- end }}
+    {{- if include "airflow.workers.extraVolumeMounts.has_log_path" . }}
+    {{ required "If `logs.path` is under any `workers.extraVolumeMounts`, then `workers.logCleanup.enabled` must be `false`!" nil }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 {{/* Checks for `logs.persistence` */}}
 {{- if .Values.logs.persistence.enabled }}
   {{- if not (eq .Values.logs.persistence.accessMode "ReadWriteMany") }}
   {{ required "The `logs.persistence.accessMode` must be `ReadWriteMany`!" nil }}
   {{- end }}
-  {{- if .Values.scheduler.logCleanup.enabled }}
-  {{ required "If `logs.persistence.enabled=true`, then `scheduler.logCleanup.enabled` must be disabled!" nil }}
-  {{- end }}
-  {{- if .Values.workers.enabled }}
-    {{- if .Values.workers.logCleanup.enabled }}
-    {{ required "If `logs.persistence.enabled=true`, then `workers.logCleanup.enabled` must be disabled!" nil }}
-    {{- end }}
+  {{- if include "airflow.extraVolumeMounts.has_log_path" . }}
+  {{ required "If `logs.path` is under any `airflow.extraVolumeMounts`, then `logs.persistence.enabled` must be `false`!" nil }}
   {{- end }}
 {{- end }}
 

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -7,7 +7,7 @@
 {{- $extraVolumeMounts := .Values.flower.extraVolumeMounts }}
 {{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
 {{- $extraVolumes := .Values.flower.extraVolumes }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -6,7 +6,7 @@
 {{- $extraVolumeMounts := .Values.scheduler.extraVolumeMounts }}
 {{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
 {{- $extraVolumes := .Values.scheduler.extraVolumes }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -7,7 +7,7 @@
 {{- $extraVolumeMounts := .Values.triggerer.extraVolumeMounts }}
 {{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
 {{- $extraVolumes := .Values.triggerer.extraVolumes }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -6,7 +6,7 @@
 {{- $extraVolumeMounts := .Values.web.extraVolumeMounts }}
 {{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
 {{- $extraVolumes := .Values.web.extraVolumes }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -7,7 +7,7 @@
 {{- $extraVolumeMounts := .Values.workers.extraVolumeMounts }}
 {{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
 {{- $extraVolumes := .Values.workers.extraVolumes }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 apiVersion: apps/v1
 ## StatefulSet gives workers consistent DNS names, allowing webserver access to log files
 kind: StatefulSet


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- fixes https://github.com/airflow-helm/charts/issues/571


## What does your PR do?

- Fixes support for `logs.path` being under a custom `airflow.extraVolumeMounts` by detecting when this happens and disabling the `emptyDir` Volume mounted at `logs.path` (originally broken by https://github.com/airflow-helm/charts/pull/554)
- Prevent using `airflow.extraVolumeMounts` for logs at the same time as log-cleanup. This is for the same reasons as with `logs.persistence`, namely that multiple pods would fight over deleting, but mostly because auto-deleting logs is usually not what the user wants if they enable persistence.
- Added `"Option 3 - Pod Volumes"` to the `"How to persist airflow logs?"` FAQ page

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated