### PR TITLE
fix: require release-name to have <= 40 characters

### DIFF
--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -1,6 +1,6 @@
 {{/* Checks for `.Release.name` */}}
-{{- if gt (len .Release.Name) 43 }}
-  {{ required "The `.Release.name` must be less than 43 characters (due to the 63 character limit for names in Kubernetes)!" nil }}
+{{- if gt (len .Release.Name) 40 }}
+  {{ required "The `.Release.name` must be <= 40 characters (due to the 63 character limit for names in Kubernetes)!" nil }}
 {{- end }}
 
 {{/* Checks for `airflow.legacyCommands` */}}

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -1,6 +1,13 @@
 {{/* Checks for `.Release.name` */}}
-{{- if gt (len .Release.Name) 40 }}
+{{/* NOTE: `allowLongReleaseName` was added when the max length dropped from 43 to 40, and is NOT intended for new deployments */}}
+{{- if .Values.allowLongReleaseName }}
+  {{- if gt (len .Release.Name) 43 }}
+  {{ required "The `.Release.name` must be <= 43 characters (due to the 63 character limit for names in Kubernetes)!" nil }}
+  {{- end }}
+{{- else }}
+  {{- if gt (len .Release.Name) 40 }}
   {{ required "The `.Release.name` must be <= 40 characters (due to the 63 character limit for names in Kubernetes)!" nil }}
+  {{- end }}
 {{- end }}
 
 {{/* Checks for `airflow.legacyCommands` */}}


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->

## What issues does your PR fix?

- fixes #588

## What does your PR do?

- Lowers the maximum length of the helm release name to `40` (down from `43`)
- This is needed because the embedded PostgreSQL and Redis charts will create a StatefulSets having a name that is `54` characters long when the helm release is `41` characters long, making it unable to create Pods (https://github.com/kubernetes/kubernetes/issues/64023)
- As an escape hatch for people with existing deployments that have release names between `41` and `43` characters, a hidden value called `allowLongReleaseName` has been added, which reverts to the previous limit of `43`.

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated