### PR TITLE
fix: some breaking changes from airflow 2.3.0

### DIFF
--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -60,6 +60,9 @@
 {{- if or (.Values.airflow.config.AIRFLOW__CORE__SQL_ALCHEMY_CONN) (.Values.airflow.config.AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD) }}
   {{ required "Don't define `airflow.config.AIRFLOW__CORE__SQL_ALCHEMY_CONN`, it will be automatically set by the chart!" nil }}
 {{- end }}
+{{- if or (.Values.airflow.config.AIRFLOW__DATABASE__SQL_ALCHEMY_CONN) (.Values.airflow.config.AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_CMD) }}
+  {{ required "Don't define `airflow.config.AIRFLOW__DATABASE__SQL_ALCHEMY_CONN`, it will be automatically set by the chart!" nil }}
+{{- end }}
 
 {{/* Checks for `logs.persistence` */}}
 {{- if .Values.logs.persistence.enabled }}

--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -119,7 +119,6 @@ data:
   {{- if .Values.airflow.fernetKey }}
   AIRFLOW__CORE__FERNET_KEY: {{ .Values.airflow.fernetKey | toString | b64enc | quote }}
   {{- end }}
-  AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD: {{ `bash -c 'eval "$DATABASE_SQLALCHEMY_CMD"'` | b64enc | quote }}
   {{- if .Values.airflow.webserverSecretKey }}
   AIRFLOW__WEBSERVER__SECRET_KEY: {{ .Values.airflow.webserverSecretKey | toString | b64enc | quote }}
   {{- end }}
@@ -135,6 +134,13 @@ data:
   ## default to the RBAC UI when in legacy mode
   AIRFLOW__WEBSERVER__RBAC: {{ "true" | b64enc | quote }}
   {{- end }}
+
+  ## ================
+  ## Airflow Configs (Database)
+  ## ================
+  AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD: {{ `bash -c 'eval "$DATABASE_SQLALCHEMY_CMD"'` | b64enc | quote }}
+  ## `core.sql_alchemy_conn` moved to `database.sql_alchemy_conn` in airflow 2.3.0
+  AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_CMD: {{ `bash -c 'eval "$DATABASE_SQLALCHEMY_CMD"'` | b64enc | quote }}
 
   ## ================
   ## Airflow Configs (Triggerer)

--- a/charts/airflow/templates/sync/_helpers/sync_users.tpl
+++ b/charts/airflow/templates/sync/_helpers/sync_users.tpl
@@ -15,7 +15,6 @@ The python sync script for users.
 ## Imports ##
 #############
 import sys
-from flask_appbuilder.security.sqla.models import User, Role
 from werkzeug.security import check_password_hash, generate_password_hash
 {{- if .Values.airflow.legacyCommands }}
 import airflow.www_rbac.app as www_app
@@ -25,6 +24,12 @@ import airflow.www.app as www_app
 flask_app = www_app.create_app()
 flask_appbuilder = flask_app.appbuilder
 {{- end }}
+
+# airflow uses its own incompatible FAB models in 2.3.0+
+try:
+  from airflow.www.fab_security.sqla.models import User, Role
+except ModuleNotFoundError:
+  from flask_appbuilder.security.sqla.models import User, Role
 
 
 #############


### PR DESCRIPTION
## What issues does your PR fix?

- partially resolves https://github.com/airflow-helm/charts/issues/572
- fixes https://github.com/airflow-helm/charts/issues/607

## What does your PR do?

- Fixes breaking changes introduced in Airflow 2.3.0 (but does not update the default airflow image tag)
   - Sets the `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_CMD` variable (as `AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD` was not correctly depreciated in Airflow 2.3.0)
   - Fixes `sync-users` script by updating imports for `User` and `Role` models, first trying `airflow.www.fab_security.sqla.models` (Airflow 2.3+) and if that fails, `flask_appbuilder.security.sqla.models` (Airflow <2.3)

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated