### PR TITLE
chore: update .helmignore to exclude docs

### DIFF
--- a/charts/airflow/.helmignore
+++ b/charts/airflow/.helmignore
@@ -40,3 +40,8 @@ Sessionx.vim
 .AppleDouble
 .LSOverride
 ._*
+
+## Chart Documentation
+/ci
+/docs
+/examples


### PR DESCRIPTION
## What issues does your PR fix?

- N/A


## What does your PR do?

- Updates the `.helmignore` file to exclude chart documentation, reducing the size of the helm package.

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated