### PR TITLE
fix: use rsync for extraPipPackages

### DIFF
--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -177,8 +177,8 @@ EXAMPLE USAGE: {{ include "airflow.init_container.install_pip_packages" (dict "R
       unset PYTHONUSERBASE && \
       pip freeze | grep -i {{ range .Values.airflow.protectedPipPackages }}-e {{ printf "%s==" . | quote }} {{ end }} > protected-packages.txt && \
       pip install --constraint ./protected-packages.txt --user {{ range .extraPipPackages }}{{ . | quote }} {{ end }} && \
-      echo "copying '/home/airflow/.local/*' to '/opt/home-airflow-local'..." && \
-      cp -r /home/airflow/.local/* /opt/home-airflow-local
+      echo "copying '/home/airflow/.local/' to '/opt/home-airflow-local/.local/'..." && \
+      rsync -ah --stats --delete /home/airflow/.local/ /opt/home-airflow-local/.local/
   volumeMounts:
     - name: home-airflow-local
       mountPath: /opt/home-airflow-local
@@ -377,6 +377,7 @@ EXAMPLE USAGE: {{ include "airflow.volumeMounts" (dict "Release" .Release "Value
 {{- if .extraPipPackages }}
 - name: home-airflow-local
   mountPath: /home/airflow/.local
+  subPath: .local
 {{- end }}
 
 {{- /* user-defined (global) */ -}}


### PR DESCRIPTION
## What issues does your PR fix?

- fixes https://github.com/airflow-helm/charts/issues/598


## What does your PR do?

- Uses `rsync --delete` for the extraPipPackages init-container, so if the init-container is rerun, any extra existing files on the `emptyDir` volume are deleted.
- Also sets the `rsync --stats` arg to highlight to users how much data is being copied (and how fast).

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated