### PR TITLE
fix: set AIRFLOW__LOGGING__WORKER_LOG_SERVER_PORT

### DIFF
--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -161,6 +161,8 @@ data:
   ## Airflow Configs (Celery)
   ## ================
   {{- if include "airflow.executor.celery_like" . }}
+  AIRFLOW__LOGGING__WORKER_LOG_SERVER_PORT: {{ "8793" | b64enc | quote }}
+  # `logging.worker_log_server_port` replaced `celery.worker_log_server_port` in airflow 2.2.0
   AIRFLOW__CELERY__WORKER_LOG_SERVER_PORT: {{ "8793" | b64enc | quote }}
   AIRFLOW__CELERY__BROKER_URL_CMD: {{ `bash -c 'eval "$REDIS_CONNECTION_CMD"'` | b64enc | quote }}
   AIRFLOW__CELERY__RESULT_BACKEND_CMD: {{ `bash -c 'eval "$DATABASE_CELERY_CMD"'` | b64enc | quote }}


### PR DESCRIPTION
## What issues does your PR fix?

- fixes https://github.com/airflow-helm/charts/issues/604


## What does your PR do?

- Sets the new `AIRFLOW__LOGGING__WORKER_LOG_SERVER_PORT` which replaced `AIRFLOW__CELERY__WORKER_LOG_SERVER_PORT` in airflow 2.2.0 (NOTE: we now set both to keep backward compatibility) 

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated