### PR TITLE
fix: only set SQLALCHEMY_DATABASE_URI in airflow 1.10

### DIFF
--- a/charts/airflow/files/webserver_config.py
+++ b/charts/airflow/files/webserver_config.py
@@ -1,8 +1,10 @@
-from airflow import configuration as conf
 from flask_appbuilder.security.manager import AUTH_DB
 
-# the SQLAlchemy connection string
-SQLALCHEMY_DATABASE_URI = conf.get('core', 'SQL_ALCHEMY_CONN')
+{{- if .Values.airflow.legacyCommands }}
+# only needed for airflow 1.10
+from airflow import configuration as conf
+SQLALCHEMY_DATABASE_URI = conf.get("core", "SQL_ALCHEMY_CONN")
+{{- end }}
 
 # use embedded DB for auth
 AUTH_TYPE = AUTH_DB


### PR DESCRIPTION
## What issues does your PR fix?

- N/A


## What does your PR do?

- Updates the default `webserver_config.py` template to only set `SQLALCHEMY_DATABASE_URI` when `airflow.legacyCommands` is `true` (as it only needs to be set for airflow 1.10).


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated