### PR TITLE
feat: add `airflow.protectedPipPackages`

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -212,6 +212,7 @@ Parameter | Description | Default
 `airflow.defaultSecurityContext` | default securityContext configs for Pods (is overridden by pod-specific values) | `{fsGroup: 0}`
 `airflow.podAnnotations` | extra annotations for airflow Pods | `{}`
 `airflow.extraPipPackages` | extra pip packages to install in airflow Pods | `[]`
+`airflow.protectedPipPackages` | pip packages that are protected from upgrade/downgrade by `extraPipPackages` | `["apache-airflow"]`
 `airflow.extraEnv` | extra environment variables for the airflow Pods | `[]`
 `airflow.extraContainers` | extra containers for the airflow Pods | `[]`
 `airflow.extraVolumeMounts` | extra VolumeMounts for the airflow Pods | `[]`

--- a/charts/airflow/docs/faq/configuration/extra-python-packages.md
+++ b/charts/airflow/docs/faq/configuration/extra-python-packages.md
@@ -19,6 +19,12 @@ You may use Pod [init-containers](https://kubernetes.io/docs/concepts/workloads/
 > Always pin a SPECIFIC package version like `torch==1.8.0` instead of `torch~=1.8.0`,
 > this reduces the likelihood of inconsistent package versions across your cluster.
 
+> 🟦 __Tip__ 🟦
+>
+> The `airflow.protectedPipPackages` value specifies a list of packages whose versions will be constrained to whatever was already installed in the image.
+> <br>
+> By default, we only protect the `apache-airflow` package, but you can extend `airflow.protectedPipPackages` with your own packages.
+
 <details>
 <summary>
   <b>Install on ALL Pods</b>

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -175,7 +175,8 @@ EXAMPLE USAGE: {{ include "airflow.init_container.install_pip_packages" (dict "R
     - "-c"
     - |
       unset PYTHONUSERBASE && \
-      pip install --user {{ range .extraPipPackages }}{{ . | quote }} {{ end }} && \
+      pip freeze | grep {{ range .Values.airflow.protectedPipPackages }}-e {{ printf "%s==" . | quote }} {{ end }} > protected-packages.txt && \
+      pip install --constraint ./protected-packages.txt --user {{ range .extraPipPackages }}{{ . | quote }} {{ end }} && \
       echo "copying '/home/airflow/.local/*' to '/opt/home-airflow-local'..." && \
       cp -r /home/airflow/.local/* /opt/home-airflow-local
   volumeMounts:

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -175,7 +175,7 @@ EXAMPLE USAGE: {{ include "airflow.init_container.install_pip_packages" (dict "R
     - "-c"
     - |
       unset PYTHONUSERBASE && \
-      pip freeze | grep {{ range .Values.airflow.protectedPipPackages }}-e {{ printf "%s==" . | quote }} {{ end }} > protected-packages.txt && \
+      pip freeze | grep -i {{ range .Values.airflow.protectedPipPackages }}-e {{ printf "%s==" . | quote }} {{ end }} > protected-packages.txt && \
       pip install --constraint ./protected-packages.txt --user {{ range .extraPipPackages }}{{ . | quote }} {{ end }} && \
       echo "copying '/home/airflow/.local/*' to '/opt/home-airflow-local'..." && \
       cp -r /home/airflow/.local/* /opt/home-airflow-local

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -209,6 +209,12 @@ airflow:
   ##
   extraPipPackages: []
 
+  ## pip packages that are protected from upgrade/downgrade by `extraPipPackages`
+  ## - [WARNING] Pods will fail to start if `extraPipPackages` would cause these packages to change versions
+  ##
+  protectedPipPackages:
+    - "apache-airflow"
+
   ## extra environment variables for the airflow Pods
   ## - spec for EnvVar:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#envvar-v1-core


### PR DESCRIPTION
## What issues does your PR fix?

- related to https://github.com/airflow-helm/charts/discussions/605
- probably related to https://github.com/airflow-helm/charts/issues/597

## What does your PR do?

- Prevents `extraPipPackages` from changing the version of any pip package listed in `airflow.protectedPipPackages`.
    - This feature works by adding a `pip --constraint` file that we generate from the filtered output of `pip freeze` when installing `extraPipPackages`.
    - The initial default for `airflow.protectedPipPackages` is `["apache-airflow"]`, which will hopefully stop people from accidentally running a different airflow version than specified in their `airflow.image.tag`.
    - ___WARNING:__ if users currently have `extraPipPackages` configs that are causing their `apache-airflow` version to be changed, their pods will now crash loop. To resolve this, they will need to remove whatever packages in `extraPipPackages` were causing the problem._
    - ___NOTE:__ users can disable this feature by setting `airflow.protectedPipPackages` to `[]`, but this is NOT RECOMMENDED as there is probably no situation in which you will want to have `extraPipPackages` cause an airflow upgrade._

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated