### PR TITLE
Make Airflow connectionsTemplates and variablesTemplates work

### DIFF
--- a/charts/airflow/templates/sync/sync-connections-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-connections-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.airflow.connections) (.Values.airflow.connectionsUpdate) }}
+{{- if and (or .Values.airflow.connections .Values.airflow.connectionsTemplates) (.Values.airflow.connectionsUpdate) }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}

--- a/charts/airflow/templates/sync/sync-connections-secret.yaml
+++ b/charts/airflow/templates/sync/sync-connections-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.airflow.connections }}
+{{- if (or .Values.airflow.connections .Values.airflow.connectionsTemplates) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/airflow/templates/sync/sync-variables-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-variables-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.airflow.variables) (.Values.airflow.variablesUpdate) }}
+{{- if and (or .Values.airflow.variables .Values.airflow.variablesTemplates) (.Values.airflow.variablesUpdate) }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}

--- a/charts/airflow/templates/sync/sync-variables-secret.yaml
+++ b/charts/airflow/templates/sync/sync-variables-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.airflow.variables }}
+{{- if (or .Values.airflow.variables .Values.airflow.variablesTemplates)  }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
## What issues does your PR fix?

- https://github.com/airflow-helm/charts/issues/618

## What does your PR do?

Prior to this PR specifying `variablesTemplates` or `connectionsTemplates` did not actually get picked up by the python code. Additionally, in order for these variables to be injected to the right pods you had to specify at least 1 variable or connection, now this is not the case (i.e. it's consistent with the documentation specified here 

- https://github.com/airflow-helm/charts/blob/main/charts/airflow/values.yaml#L145-L148
- https://github.com/airflow-helm/charts/blob/main/charts/airflow/values.yaml#L80-L95

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

