### PR TITLE
feat: add `dags.gitSync.submodules` value

### DIFF
--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -229,7 +229,7 @@ EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release 
     - name: GIT_SYNC_MAX_SYNC_FAILURES
       value: {{ .Values.dags.gitSync.maxFailures | quote }}
     - name: GIT_SYNC_SUBMODULES
-      value: {{ .Values.dags.gitSync.submoduleStrategy | quote }}
+      value: {{ .Values.dags.gitSync.submodules | quote }}
     {{- if .Values.dags.gitSync.sshSecret }}
     - name: GIT_SYNC_SSH
       value: "true"

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -228,6 +228,8 @@ EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release 
       value: "true"
     - name: GIT_SYNC_MAX_SYNC_FAILURES
       value: {{ .Values.dags.gitSync.maxFailures | quote }}
+    - name: GIT_SYNC_SUBMODULES
+      value: {{ .Values.dags.gitSync.submoduleStrategy | quote }}
     {{- if .Values.dags.gitSync.sshSecret }}
     - name: GIT_SYNC_SSH
       value: "true"

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1363,7 +1363,7 @@ dags:
     ## the git submodule behavior
     ## - allowed values: "recursive", "shallow", "off"
     ##
-    submoduleStrategy: recursive
+    submodules: recursive
 
     ## the name of a pre-created Secret with git http credentials
     ##

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1360,6 +1360,10 @@ dags:
     ##
     syncTimeout: 120
 
+    ## the git submodule behavior to use for syncs: one of 'recursive', 'shallow', or 'off'
+    ##
+    submoduleStrategy: recursive
+
     ## the name of a pre-created Secret with git http credentials
     ##
     httpSecret: ""

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1360,7 +1360,8 @@ dags:
     ##
     syncTimeout: 120
 
-    ## the git submodule behavior to use for syncs: one of 'recursive', 'shallow', or 'off'
+    ## the git submodule behavior
+    ## - allowed values: "recursive", "shallow", "off"
     ##
     submoduleStrategy: recursive
 


### PR DESCRIPTION
Signed-off-by: Burak Karakan <burak.karakan@gmail.com>

## What issues does your PR fix?

- N/A

## What does your PR do?

This PR introduces a new value `dags.gitSync.submodules` (default: `recursive`) to control the submodule strategy for git-sync pods.

In my use case, the repo that is being cloned has a lot of submodules, but I would rather not init the submodules because it takes 20+ seconds, therefore I want to be able to disable the submodules to significantly speed up my tasks.

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated