### PR TITLE
Update airflow-role.yaml

### DIFF
--- a/charts/airflow/templates/rbac/airflow-role.yaml
+++ b/charts/airflow/templates/rbac/airflow-role.yaml
@@ -35,7 +35,6 @@ rules:
   - "pods/log"
   verbs:
   - "get"
-  - "list"
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
## What issues does your PR fix?

N/A


## What does your PR do?

Removing invalid verb: list, from the pods/log resource in airflow role. List is not a valid verb for pods/log as per the kubernetes api spec. It appears that the only valid verb for pods/log is get, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#get-read-log-of-the-specified-pod
