### PR TITLE
feat: add `airflow.defaultContainerSecurityContext` value

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -206,6 +206,7 @@ Parameter | Description | Default
 `airflow.defaultAffinity` | default affinity configs for airflow Pods (is overridden by pod-specific values) | `{}`
 `airflow.defaultTolerations` | default toleration configs for airflow Pods (is overridden by pod-specific values) | `[]`
 `airflow.defaultSecurityContext` | default securityContext configs for Pods (is overridden by pod-specific values) | `{fsGroup: 0}`
+`airflow.defaultContainerSecurityContext` | default securityContext for Containers in airflow Pods | `{}`
 `airflow.podAnnotations` | extra annotations for airflow Pods | `{}`
 `airflow.extraPipPackages` | extra pip packages to install in airflow Pods | `[]`
 `airflow.protectedPipPackages` | pip packages that are protected from upgrade/downgrade by `extraPipPackages` | `["apache-airflow"]`

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -7,7 +7,9 @@ imagePullPolicy: {{ .Values.airflow.image.pullPolicy }}
 securityContext:
   runAsUser: {{ .Values.airflow.image.uid }}
   runAsGroup: {{ .Values.airflow.image.gid }}
+  {{- if .Values.airflow.defaultContainerSecurityContext }}
   {{- omit .Values.airflow.defaultContainerSecurityContext "runAsUser" "runAsGroup" | toYaml | nindent 2 }}
+  {{- end }}
 {{- end }}
 
 {{/*
@@ -200,7 +202,9 @@ EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release 
   securityContext:
     runAsUser: {{ .Values.dags.gitSync.image.uid }}
     runAsGroup: {{ .Values.dags.gitSync.image.gid }}
+    {{- if .Values.airflow.defaultContainerSecurityContext }}
     {{- omit .Values.airflow.defaultContainerSecurityContext "runAsUser" "runAsGroup" | toYaml | nindent 4 }}
+    {{- end }}
   resources:
     {{- toYaml .Values.dags.gitSync.resources | nindent 4 }}
   envFrom:

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -7,6 +7,7 @@ imagePullPolicy: {{ .Values.airflow.image.pullPolicy }}
 securityContext:
   runAsUser: {{ .Values.airflow.image.uid }}
   runAsGroup: {{ .Values.airflow.image.gid }}
+  {{- omit .Values.airflow.defaultContainerSecurityContext "runAsUser" "runAsGroup" | toYaml | nindent 2 }}
 {{- end }}
 
 {{/*
@@ -199,6 +200,7 @@ EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release 
   securityContext:
     runAsUser: {{ .Values.dags.gitSync.image.uid }}
     runAsGroup: {{ .Values.dags.gitSync.image.gid }}
+    {{- omit .Values.airflow.defaultContainerSecurityContext "runAsUser" "runAsGroup" | toYaml | nindent 4 }}
   resources:
     {{- toYaml .Values.dags.gitSync.resources | nindent 4 }}
   envFrom:

--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -84,6 +84,7 @@ spec:
           securityContext:
             runAsUser: {{ .Values.pgbouncer.image.uid }}
             runAsGroup: {{ .Values.pgbouncer.image.gid }}
+            {{- omit .Values.airflow.defaultContainerSecurityContext "runAsUser" "runAsGroup" | toYaml | nindent 12 }}
           resources:
             {{- toYaml .Values.pgbouncer.resources | nindent 12 }}
           envFrom:

--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -84,7 +84,9 @@ spec:
           securityContext:
             runAsUser: {{ .Values.pgbouncer.image.uid }}
             runAsGroup: {{ .Values.pgbouncer.image.gid }}
+            {{- if .Values.airflow.defaultContainerSecurityContext }}
             {{- omit .Values.airflow.defaultContainerSecurityContext "runAsUser" "runAsGroup" | toYaml | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.pgbouncer.resources | nindent 12 }}
           envFrom:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -197,6 +197,14 @@ airflow:
     ## this does NOT give root permissions to Pods, only the "root" group
     fsGroup: 0
 
+  ## default securityContext for Containers in airflow Pods
+  ## - `runAsUser` is ignored, please set with per-image `*.image.uid`
+  ## - `runAsGroup` is ignored, please set with per-image `*.image.gid`
+  ## - spec for SecurityContext:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#securitycontext-v1-core
+  ##
+  defaultContainerSecurityContext: {}
+
   ## extra annotations for airflow Pods
   ##
   podAnnotations: {}
@@ -2029,7 +2037,7 @@ redis:
       ## the access mode of the PVC
       ##
       accessModes:
-      - ReadWriteOnce
+        - ReadWriteOnce
 
       ## the size of PVC to request
       ##

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -198,10 +198,10 @@ airflow:
     fsGroup: 0
 
   ## default securityContext for Containers in airflow Pods
-  ## - `runAsUser` is ignored, please set with per-image `*.image.uid`
-  ## - `runAsGroup` is ignored, please set with per-image `*.image.gid`
   ## - spec for SecurityContext:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#securitycontext-v1-core
+  ## - `runAsUser` is ignored, please set with per-image `*.image.uid`
+  ## - `runAsGroup` is ignored, please set with per-image `*.image.gid`
   ##
   defaultContainerSecurityContext: {}
 


### PR DESCRIPTION
Signed-off-by: Philipp Hitzler <philipp.hitzler@idealo.de>

<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->

## What issues does your PR fix?

- fixes #578 (except for Postgres and Redis)

## What does your PR do?

This PR adds the following values: 

- `airflow.defaultContainerSecurityContext` (default: `{}`)
     - Sets the Container SecurityContext of all airflow containers (including PGBouncer)
     - Does not set `runAsUser` and `runAsGroup` (those are set per-image with the `*.image.uid` and `*.image.gid` values)
     - Will NOT set Container SecurityContext of embedded Postgres or Redis due to still using the old charts:
         - #303 
         - #304

@thesuperzapper all code is taken from your https://github.com/airflow-helm/charts/issues/578#issuecomment-1147170097

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated