### PR TITLE
feat: allow disabling chart-managed `webserver_config.py`

### DIFF
--- a/charts/airflow/docs/faq/configuration/airflow-configs.md
+++ b/charts/airflow/docs/faq/configuration/airflow-configs.md
@@ -74,6 +74,10 @@ web:
     ## the name of an existing Secret containing a `webserver_config.py` key
     ## NOTE: if set, takes precedence over `web.webserverConfig.stringOverride`
     #existingSecret: "my-airflow-webserver-config"
+
+    ## if the `webserver_config.py` file is mounted
+    ## NOTE: set to false if you wish to mount your own `webserver_config.py` file
+    #enabled: false
 ```
 
 > 🟦 __Tip__ 🟦

--- a/charts/airflow/templates/config/secret-webserver-config.yaml
+++ b/charts/airflow/templates/config/secret-webserver-config.yaml
@@ -1,4 +1,4 @@
-{{- if (and .Values.web.webserverConfig.enabled (not .Values.web.webserverConfig.existingSecret)) }}
+{{- if and (.Values.web.webserverConfig.enabled) (not .Values.web.webserverConfig.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/airflow/templates/config/secret-webserver-config.yaml
+++ b/charts/airflow/templates/config/secret-webserver-config.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.web.webserverConfig.existingSecret }}
+{{- if (and .Values.web.webserverConfig.enabled (not .Values.web.webserverConfig.existingSecret)) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -42,7 +42,9 @@ spec:
       annotations:
         checksum/secret-config-envs: {{ include (print $.Template.BasePath "/config/secret-config-envs.yaml") . | sha256sum }}
         checksum/secret-local-settings: {{ include (print $.Template.BasePath "/config/secret-local-settings.yaml") . | sha256sum }}
+        {{- if .Values.web.webserverConfig.enabled }}
         checksum/config-webserver-config: {{ include (print $.Template.BasePath "/config/secret-webserver-config.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.airflow.podAnnotations }}
         {{- toYaml .Values.airflow.podAnnotations | nindent 8 }}
         {{- end }}
@@ -136,10 +138,12 @@ spec:
           {{- end }}
           volumeMounts:
             {{- $volumeMounts | indent 12 }}
+            {{- if .Values.web.webserverConfig.enabled }}
             - name: webserver-config
               mountPath: /opt/airflow/webserver_config.py
               subPath: webserver_config.py
               readOnly: true
+            {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
         {{- include "airflow.container.git_sync" . | indent 8 }}
         {{- end }}
@@ -148,6 +152,7 @@ spec:
         {{- end }}
       volumes:
         {{- $volumes | indent 8 }}
+        {{- if .Values.web.webserverConfig.enabled }}
         - name: webserver-config
           secret:
             {{- if .Values.web.webserverConfig.existingSecret }}
@@ -156,3 +161,4 @@ spec:
             secretName: {{ include "airflow.fullname" . }}-webserver-config
             {{- end }}
             defaultMode: 0644
+        {{- end }}

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -42,7 +42,7 @@ spec:
       annotations:
         checksum/secret-config-envs: {{ include (print $.Template.BasePath "/config/secret-config-envs.yaml") . | sha256sum }}
         checksum/secret-local-settings: {{ include (print $.Template.BasePath "/config/secret-local-settings.yaml") . | sha256sum }}
-        {{- if .Values.web.webserverConfig.enabled }}
+        {{- if and (.Values.web.webserverConfig.enabled) (not .Values.web.webserverConfig.existingSecret) }}
         checksum/config-webserver-config: {{ include (print $.Template.BasePath "/config/secret-webserver-config.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.airflow.podAnnotations }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -664,6 +664,10 @@ web:
   ########################################
   ##
   webserverConfig:
+    ## by default, the helm chart owns the webserver config, however, sometimes it may be on a
+    ## custom version of the image. If this is the case, set this to false
+    enabled: true
+
     ## the full content of the `webserver_config.py` file (as a string)
     ## - docs for Flask-AppBuilder security configs:
     ##   https://flask-appbuilder.readthedocs.io/en/latest/security.html

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -664,8 +664,9 @@ web:
   ########################################
   ##
   webserverConfig:
-    ## by default, the helm chart owns the webserver config, however, sometimes it may be on a
-    ## custom version of the image. If this is the case, set this to false
+    ## if the `webserver_config.py` file is mounted
+    ## - set to false if you wish to mount your own `webserver_config.py` file
+    ##
     enabled: true
 
     ## the full content of the `webserver_config.py` file (as a string)


### PR DESCRIPTION
## What does your PR do?

Allow users to disable the chart-managed `webserver_config.py`:
- this can be used when the container image has a `webserver_config.py` file baked in, or when the user wants to mount the file with a custom volume mount
- new value `web.webserverConfig.enabled` (default: `true`)