### PR TITLE
feat: add revisionHistoryLimit to all deployment components

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -229,6 +229,7 @@ Parameter | Description | Default
 Parameter | Description | Default
 --- | --- | ---
 `scheduler.replicas` | the number of scheduler Pods to run | `1`
+`scheduler.revisionHistoryLimit` | the limit number of deployment revision history | `null`
 `scheduler.resources` | resource requests/limits for the scheduler Pods | `{}`
 `scheduler.nodeSelector` | the nodeSelector configs for the scheduler Pods | `{}`
 `scheduler.affinity` | the affinity configs for the scheduler Pods | `{}`
@@ -257,6 +258,7 @@ Parameter | Description | Default
 --- | --- | ---
 `web.webserverConfig.*` | configs to generate webserver_config.py | `<see values.yaml>`
 `web.replicas` | the number of web Pods to run | `1`
+`web.revisionHistoryLimit` | the limit number of deployment revision history | `null`
 `web.resources` | resource requests/limits for the airflow web pods | `{}`
 `web.nodeSelector` | the number of web Pods to run | `{}`
 `web.affinity` | the affinity configs for the web Pods | `{}`
@@ -312,6 +314,7 @@ Parameter | Description | Default
 --- | --- | ---
 `triggerer.enabled` | if the triggerer should be deployed | `true`
 `triggerer.replicas` | the number of triggerer Pods to run | `1`
+`triggerer.revisionHistoryLimit` | the limit number of deployment revision history | `null`
 `triggerer.resources` | resource requests/limits for the airflow triggerer Pods | `{}`
 `triggerer.nodeSelector` | the nodeSelector configs for the triggerer Pods | `{}`
 `triggerer.affinity` | the affinity configs for the triggerer Pods | `{}`
@@ -337,6 +340,8 @@ Parameter | Description | Default
 Parameter | Description | Default
 --- | --- | ---
 `flower.enabled` | if the Flower UI should be deployed | `true`
+`flower.replicas` | the number of flower Pods to run | `1`
+`flower.revisionHistoryLimit` | the limit number of deployment revision history | `null`
 `flower.resources` | resource requests/limits for the flower Pods | `{}`
 `flower.nodeSelector` | the nodeSelector configs for the flower Pods | `{}`
 `flower.affinity` | the affinity configs for the flower Pods | `{}`
@@ -426,6 +431,7 @@ Parameter | Description | Default
 Parameter | Description | Default
 --- | --- | ---
 `pgbouncer.enabled` | if the pgbouncer Deployment is created | `true`
+`pgbouncer.revisionHistoryLimit` | the limit number of deployment revision history | `null`
 `pgbouncer.image.*` | configs for the pgbouncer container image | `<see values.yaml>`
 `pgbouncer.resources` | resource requests/limits for the pgbouncer Pods | `{}`
 `pgbouncer.nodeSelector` | the nodeSelector configs for the pgbouncer Pods | `{}`

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -27,6 +27,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.flower.replicas }}
+  {{- if .Values.flower.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.flower.revisionHistoryLimit }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -22,6 +22,9 @@ metadata:
   {{- end }}
 spec:
   replicas: 1
+  {{- if .Values.pgbouncer.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.pgbouncer.revisionHistoryLimit }}
+  {{- end }}
   strategy:
     rollingUpdate:
       ## multiple pgbouncer pods can safely run concurrently

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -26,6 +26,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.scheduler.replicas }}
+  {{- if .Values.scheduler.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.scheduler.revisionHistoryLimit }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -27,6 +27,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.triggerer.replicas }}
+  {{- if .Values.triggerer.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.triggerer.revisionHistoryLimit }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -26,6 +26,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.web.replicas }}
+  {{- if .Values.web.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.web.revisionHistoryLimit }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -502,6 +502,12 @@ scheduler:
   ##
   replicas: 1
 
+  ## the limit number of deployment revision history
+  ## - docs for revisionHistoryLimit:
+  ##   https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit
+  ##
+  revisionHistoryLimit:
+
   ## resource requests/limits for the scheduler Pod
   ## - spec of ResourceRequirements:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
@@ -689,6 +695,12 @@ web:
   ## - if you set this >1 we recommend defining a `web.podDisruptionBudget`
   ##
   replicas: 1
+
+  ## the limit number of deployment revision history
+  ## - docs for revisionHistoryLimit:
+  ##   https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit
+  ##
+  revisionHistoryLimit:
 
   ## resource requests/limits for the web Pod
   ## - spec for ResourceRequirements:
@@ -990,6 +1002,12 @@ triggerer:
   ##
   replicas: 1
 
+  ## the limit number of deployment revision history
+  ## - docs for revisionHistoryLimit:
+  ##   https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit
+  ##
+  revisionHistoryLimit:
+
   ## resource requests/limits for the triggerer Pods
   ## - spec for ResourceRequirements:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
@@ -1100,6 +1118,12 @@ flower:
   ## - if you set this >1 we recommend defining a `flower.podDisruptionBudget`
   ##
   replicas: 1
+
+  ## the limit number of deployment revision history
+  ## - docs for revisionHistoryLimit:
+  ##   https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit
+  ##
+  revisionHistoryLimit:
 
   ## resource requests/limits for the flower Pod
   ## - spec for ResourceRequirements:
@@ -1638,6 +1662,12 @@ pgbouncer:
   ## if the pgbouncer Deployment is created
   ##
   enabled: true
+
+  ## the limit number of deployment revision history
+  ## - docs for revisionHistoryLimit:
+  ##   https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit
+  ##
+  revisionHistoryLimit:
 
   ## configs for the pgbouncer container image
   ##


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->

## What does your PR do?

* Can configure revisionHistoryLimit of Deployment using values

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated