### PR TITLE
fix: use policy/v1 (instead of policy/v1beta1) for PodDistributionBudgets

### DIFF
--- a/charts/airflow/templates/flower/flower-pdb.yaml
+++ b/charts/airflow/templates/flower/flower-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.flower.enabled) (.Values.flower.podDisruptionBudget.enabled) }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "airflow.fullname" . }}-flower

--- a/charts/airflow/templates/pgbouncer/pgbouncer-pdb.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and (include "airflow.pgbouncer.should_use" .) (.Values.pgbouncer.podDisruptionBudget.enabled) }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "airflow.fullname" . }}-pgbouncer

--- a/charts/airflow/templates/scheduler/scheduler-pdb.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.scheduler.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "airflow.fullname" . }}-scheduler

--- a/charts/airflow/templates/triggerer/triggerer-pdb.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and (include "airflow.triggerer.should_use" .) (.Values.triggerer.podDisruptionBudget.enabled) }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "airflow.fullname" . }}-triggerer

--- a/charts/airflow/templates/webserver/webserver-pdb.yaml
+++ b/charts/airflow/templates/webserver/webserver-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.web.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "airflow.fullname" . }}-web

--- a/charts/airflow/templates/worker/worker-pdb.yaml
+++ b/charts/airflow/templates/worker/worker-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.workers.enabled) (.Values.workers.podDisruptionBudget.enabled) }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "airflow.fullname" . }}-worker


### PR DESCRIPTION
Signed-off-by: Matthew Byng-Maddick <mbyng-maddick@olx.com>

## What does your PR do?

This PR adjusts the `apiVersion` of `PodDistributionBudgets` to `policy/v1`

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [ ] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated