### PR TITLE
docs: fix relative link anchors to readme

### DIFF
--- a/charts/airflow/docs/faq/configuration/airflow-version.md
+++ b/charts/airflow/docs/faq/configuration/airflow-version.md
@@ -8,7 +8,7 @@
 >
 > There is a default version of airflow shipped with each version of the chart, see the [default `values.yaml`](../../../values.yaml) for the current one.
 >
-> Many versions of airflow versions are supported by the chart, please see the [Airflow Version Support](../../..#airflow-version-support) matrix.
+> Many versions of airflow versions are supported by the chart, please see the [Airflow Version Support](../../../README.md#airflow-version-support) matrix.
 
 ## Airflow 2.X
 

--- a/charts/airflow/docs/guides/quickstart.md
+++ b/charts/airflow/docs/guides/quickstart.md
@@ -59,10 +59,10 @@ We recommend that you start your `custom-values.yaml` file from one of our sampl
 > 
 > The following links should help you extend your `custom-values.yaml` to suit your needs:
 >
-> - [`Docs: Key Features`](../..#key-features)
-> - [`Docs: Frequently Asked Questions`](../..#frequently-asked-questions)
-> - [`Docs: Examples`](../..#examples)
-> - [`Docs: Helm Values`](../..#helm-values)
+> - [`Docs: Key Features`](../../README.md#key-features)
+> - [`Docs: Frequently Asked Questions`](../../README.md#frequently-asked-questions)
+> - [`Docs: Examples`](../../README.md#examples)
+> - [`Docs: Helm Values`](../../README.md#helm-values)
 
 > 🟦 __Tip__ 🟦
 >


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- broken links in documentation


## What does your PR do?

This PR makes the following changes...


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] ~~Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)~~
- [ ] ~~CHANGELOG.md updated~~