### PR TITLE
feat: Small update on git-sync container image reference

### DIFF
--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1310,7 +1310,7 @@ dags:
     ## the git-sync container image
     ##
     image:
-      repository: k8s.gcr.io/git-sync/git-sync
+      repository: registry.k8s.io/git-sync/git-sync
       tag: v3.5.0
       pullPolicy: IfNotPresent
       uid: 65533


### PR DESCRIPTION
## What does your PR do?

Starting April 3, 2023, the Kubernetes project will stop publishing community-owned images (known as community images) to the old image registry k8s.gcr.io, registry.k8s.io replaces it.

## Checklist

### For all Pull Requests

- [ ] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [ ] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [ ] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)