### PR TITLE
fix: also set `kubernetes_executor` airflow configs

### DIFF
--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -182,17 +182,21 @@ data:
   ## Airflow Configs (Kubernetes)
   ## ================
   {{- if include "airflow.executor.kubernetes_like" . }}
-  {{- if not .Values.airflow.config.AIRFLOW__KUBERNETES__NAMESPACE }}
+  {{- if not (or .Values.airflow.config.AIRFLOW__KUBERNETES__NAMESPACE .Values.airflow.config.AIRFLOW__KUBERNETES_EXECUTOR__NAMESPACE) }}
   AIRFLOW__KUBERNETES__NAMESPACE: {{ .Release.Namespace | toString | b64enc | quote }}
+  AIRFLOW__KUBERNETES_EXECUTOR__NAMESPACE: {{ .Release.Namespace | toString | b64enc | quote }}
   {{- end }}
-  {{- if not .Values.airflow.config.AIRFLOW__KUBERNETES__WORKER_CONTAINER_REPOSITORY }}
+  {{- if not (or .Values.airflow.config.AIRFLOW__KUBERNETES__WORKER_CONTAINER_REPOSITORY .Values.airflow.config.AIRFLOW__KUBERNETES_EXECUTOR__WORKER_CONTAINER_REPOSITORY) }}
   AIRFLOW__KUBERNETES__WORKER_CONTAINER_REPOSITORY: {{ .Values.airflow.image.repository | toString | b64enc | quote }}
+  AIRFLOW__KUBERNETES_EXECUTOR__WORKER_CONTAINER_REPOSITORY: {{ .Values.airflow.image.repository | toString | b64enc | quote }}
   {{- end }}
-  {{- if not .Values.airflow.config.AIRFLOW__KUBERNETES__WORKER_CONTAINER_TAG }}
+  {{- if not (or .Values.airflow.config.AIRFLOW__KUBERNETES__WORKER_CONTAINER_TAG .Values.airflow.config.AIRFLOW__KUBERNETES_EXECUTOR__WORKER_CONTAINER_TAG) }}
   AIRFLOW__KUBERNETES__WORKER_CONTAINER_TAG: {{ .Values.airflow.image.tag | toString | b64enc | quote }}
+  AIRFLOW__KUBERNETES_EXECUTOR__WORKER_CONTAINER_TAG: {{ .Values.airflow.image.tag | toString | b64enc | quote }}
   {{- end }}
-  {{- if not .Values.airflow.config.AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE }}
+  {{- if not (or .Values.airflow.config.AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE .Values.airflow.config.AIRFLOW__KUBERNETES_EXECUTOR__POD_TEMPLATE_FILE) }}
   AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE: {{ "/opt/airflow/pod_templates/pod_template.yaml" | b64enc | quote }}
+  AIRFLOW__KUBERNETES_EXECUTOR__POD_TEMPLATE_FILE: {{ "/opt/airflow/pod_templates/pod_template.yaml" | b64enc | quote }}
   {{- end }}
 
   {{- if .Values.airflow.legacyCommands }}


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- fixes #677

## What does your PR do?

This PR additionally sets the `kubernetes_executor` equivalent of any `kubernetes` airflow configs we set, to suppress deprecation warnings in pod logs.

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)