### PR TITLE
Differentiate "plugins" from "dags" by adding new variables supporting syncing with a separate Github repository.

### DIFF
--- a/charts/airflow/CHANGELOG.md
+++ b/charts/airflow/CHANGELOG.md
@@ -765,7 +765,8 @@ TBD
 >
 > - To read about versions `7.0.0` and before, please see the [legacy repo](https://github.com/helm/charts/tree/master/stable/airflow).
 
-[Unreleased]: https://github.com/airflow-helm/charts/compare/airflow-8.7.0...HEAD
+[Unreleased]: https://github.com/airflow-helm/charts/compare/airflow-8.8.0...HEAD
+[8.8.0]: https://github.com/airflow-helm/charts/compare/airflow-8.7.0...airflow-8.8.0
 [8.7.0]: https://github.com/airflow-helm/charts/compare/airflow-8.6.1...airflow-8.7.0
 [8.6.1]: https://github.com/airflow-helm/charts/compare/airflow-8.6.0...airflow-8.6.1
 [8.6.0]: https://github.com/airflow-helm/charts/compare/airflow-8.5.3...airflow-8.6.0

--- a/charts/airflow/CHANGELOG.md
+++ b/charts/airflow/CHANGELOG.md
@@ -8,6 +8,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 
 TBD
 
+## 8.8.0 - 2023-04-17
+
+> 🟨 __NOTES__ 🟨
+>
+> - In order to avoid confusion with the names of the existing parameters related to the `dags.gitSync` variable, it is decised to rename the parameters git-sync with dags-git-sync and plugins-git-sync correspondingly. Affected parameters: airflow.container.git_sync to airflow.container.dags_git_sync
+
+### Added
+- added `plugins.*` values with the same structure as in the `dags.*` variables, in order to differentiate git-sync for both "dags" and "plugins", so "dags" and "airflow plugins" can be pulled from separate repositories.
+- added AIRFLOW__CORE__PLUGINS_FOLDER environment variable to point to the "plugins" folder
+
 ## [8.7.0] - 2023-04-06
 
 > 🟥 __WARNINGS__ 🟥

--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Airflow Helm Chart (User Community) - the standard way to deploy Apache Airflow on Kubernetes with Helm
 name: airflow
-version: 8.7.0
+version: 8.8.0
 appVersion: 2.5.3
 icon: https://avatars.githubusercontent.com/u/71061241
 home: https://github.com/airflow-helm/charts/tree/main/charts/airflow

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -380,6 +380,17 @@ Parameter | Description | Default
 </details>
 
 <details>
+<summary><code>plugins.*</code></summary>
+
+Parameter | Description | Default
+--- | --- | ---
+`plugins.path` | the airflow plugins folder | `/opt/airflow/plugins`
+`plugins.persistence.*` | configs for the plugins PVC | `<see values.yaml>`
+`plugins.gitSync.*` | configs for the git-sync sidecar  | `<see values.yaml>`
+
+</details>
+
+<details>
 <summary><code>ingress.*</code></summary>
 
 Parameter | Description | Default

--- a/charts/airflow/examples/google-gke/custom-values.yaml
+++ b/charts/airflow/examples/google-gke/custom-values.yaml
@@ -350,6 +350,56 @@ dags:
         memory: "64Mi"
 
 ###################################
+## CONFIG | Airflow Plugins
+###################################
+plugins:
+  ## the airflow plugins folder
+  path: /opt/airflow/plugins
+
+  ## configs for the plugins PVC
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/plugins/load-dag-definitions.md
+  persistence:
+    enabled: false
+
+  ## configs for the git-sync sidecar
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/plugins/load-dag-definitions.md
+  gitSync:
+    enabled: true
+
+    ## the url of the git repo
+    repo: "git@github.com:USERNAME/REPOSITORY.git"
+
+    ## the git branch to check out
+    branch: master
+
+    ## the git revision (tag or hash) to check out
+    revision: HEAD
+
+    ## the name of a pre-created Secret with git ssh credentials
+    sshSecret: "airflow-cluster1-git-secret"
+    sshSecretKey: "id_rsa"
+
+    ## the string value of a "known_hosts" file (for SSH only)
+    ## NOTE: "known_hosts" verification can be disabled by setting to ""
+    sshKnownHosts: |-
+      github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+
+    ## number of seconds to wait between syncs
+    ## [NOTE] also sets `AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL` unless overwritten in `airflow.config`
+    syncWait: 60
+
+    ## the sub-path within your repo where plugins are located
+    ## [NOTE] airflow will only see plugins under this path, but the whole repo will still be synced
+    #repoSubPath: "path/to/plugins"
+
+    ## resource requests/limits for the git-sync container
+    ## [SPEC] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "64Mi"
+
+###################################
 ## CONFIG | Kubernetes Ingress
 ###################################
 ingress:

--- a/charts/airflow/examples/minikube/custom-values.yaml
+++ b/charts/airflow/examples/minikube/custom-values.yaml
@@ -240,6 +240,24 @@ dags:
     repo: "https://github.com/USERNAME/REPOSITORY.git"
 
 ###################################
+## CONFIG | Airflow Plugins
+###################################
+plugins:
+  ## the airflow plugins folder
+  path: /opt/airflow/plugins
+
+  ## configs for the plugins PVC
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/plugins/load-dag-definitions.md
+  persistence:
+    enabled: false
+
+  ## configs for the git-sync sidecar
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/plugins/load-dag-definitions.md
+  gitSync:
+    enabled: true
+    repo: "https://github.com/USERNAME/REPOSITORY.git"
+
+###################################
 ## CONFIG | Kubernetes Ingress
 ###################################
 ingress:

--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -43,13 +43,16 @@ spec:
   securityContext:
     {{- $podSecurityContext | nindent 4 }}
   {{- end }}
-  {{- if or ($extraPipPackages) (.Values.dags.gitSync.enabled) (.Values.airflow.kubernetesPodTemplate.extraInitContainers) }}
+  {{- if or ($extraPipPackages) (.Values.dags.gitSync.enabled) (.Values.plugins.gitSync.enabled) (.Values.airflow.kubernetesPodTemplate.extraInitContainers) }}
   initContainers:
     {{- if $extraPipPackages }}
     {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 4 }}
     {{- end }}
     {{- if .Values.dags.gitSync.enabled }}
-    {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 4 }}
+    {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 4 }}
+    {{- end }}
+    {{- if .Values.plugins.gitSync.enabled }}
+    {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 4 }}
     {{- end }}
     {{- if .Values.airflow.kubernetesPodTemplate.extraInitContainers }}
     {{- toYaml .Values.airflow.kubernetesPodTemplate.extraInitContainers | nindent 4 }}

--- a/charts/airflow/sample-values-CeleryExecutor.yaml
+++ b/charts/airflow/sample-values-CeleryExecutor.yaml
@@ -217,6 +217,23 @@ dags:
   ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/dags/load-dag-definitions.md
   gitSync:
     enabled: false
+    
+###################################
+## CONFIG | Airflow Plugins
+###################################
+plugins:
+  ## the airflow plugins folder
+  path: /opt/airflow/plugins
+
+  ## configs for the plugins PVC
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/plugins/load-plugins-definitions.md
+  persistence:
+    enabled: false
+
+  ## configs for the plugins-git-sync sidecar
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/plugins/load-plugins-definitions.md
+  gitSync:
+    enabled: false         
 
 ###################################
 ## CONFIG | Kubernetes Ingress

--- a/charts/airflow/sample-values-CeleryKubernetesExecutor.yaml
+++ b/charts/airflow/sample-values-CeleryKubernetesExecutor.yaml
@@ -72,7 +72,8 @@ airflow:
   extraVolumes: []
 
   ## configs generating the `pod_template.yaml` file for `AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE`
-  ## [NOTE] the `dags.gitSync` values will create a git-sync init-container in the pod
+  ## [NOTE] the `dags.gitSync` values will create a dags-git-sync init-container in the pod
+  ## [NOTE] the `plugins.gitSync` values will create a plugins-git-sync init-container in the pod
   ## [NOTE] the `airflow.extraPipPackages` will NOT be installed
   kubernetesPodTemplate:
 
@@ -243,6 +244,23 @@ dags:
 
   ## configs for the git-sync sidecar
   ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/dags/load-dag-definitions.md
+  gitSync:
+    enabled: false
+    
+###################################
+## CONFIG | Airflow Plugins
+###################################
+plugins:
+  ## the airflow plugins folder
+  path: /opt/airflow/plugins
+
+  ## configs for the plugins PVC
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/plugins/load-plugins-definitions.md
+  persistence:
+    enabled: false
+
+  ## configs for the plugins-git-sync sidecar
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/plugins/load-plugins-definitions.md
   gitSync:
     enabled: false
 

--- a/charts/airflow/sample-values-KubernetesExecutor.yaml
+++ b/charts/airflow/sample-values-KubernetesExecutor.yaml
@@ -72,7 +72,8 @@ airflow:
   extraVolumes: []
 
   ## configs generating the `pod_template.yaml` file for `AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE`
-  ## [NOTE] the `dags.gitSync` values will create a git-sync init-container in the pod
+  ## [NOTE] the `dags.gitSync` values will create a dags-git-sync init-container in the pod
+  ## [NOTE] the `plugins.gitSync` values will create a plugins-git-sync init-container in the pod
   ## [NOTE] the `airflow.extraPipPackages` will NOT be installed
   kubernetesPodTemplate:
 
@@ -218,6 +219,23 @@ dags:
 
   ## configs for the git-sync sidecar
   ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/dags/load-dag-definitions.md
+  gitSync:
+    enabled: false
+    
+###################################
+## CONFIG | Airflow Plugins
+###################################
+plugins:
+  ## the airflow plugins folder
+  path: /opt/airflow/plugins
+
+  ## configs for the plugins PVC
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/plugins/load-plugins-definitions.md
+  persistence:
+    enabled: false
+
+  ## configs for the plugins-git-sync sidecar
+  ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/plugins/load-plugins-definitions.md
   gitSync:
     enabled: false
 

--- a/charts/airflow/templates/_helpers/common.tpl
+++ b/charts/airflow/templates/_helpers/common.tpl
@@ -84,6 +84,17 @@ The path containing DAG files
 {{- end -}}
 
 {{/*
+The path containing Plugins files
+*/}}
+{{- define "airflow.plugins.path" -}}
+{{- if .Values.plugins.gitSync.enabled -}}
+{{- printf "%s/repo/%s" (.Values.plugins.path | trimSuffix "/") (.Values.plugins.gitSync.repoSubPath | trimAll "/") -}}
+{{- else -}}
+{{- printf .Values.plugins.path -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Helper template which checks if `logs.path` is stored under any of the passed `volumeMounts`.
 EXAMPLE USAGE: {{ include "airflow._has_logs_path" (dict "Values" .Values "volume_mounts" .Values.xxxx.extraVolumeMounts) }}
 */}}

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -58,6 +58,9 @@
 {{- if or .Values.airflow.config.AIRFLOW__CORE__DAGS_FOLDER }}
   {{ required "Don't define `airflow.config.AIRFLOW__CORE__DAGS_FOLDER`, it will be automatically set from `dags.path`!" nil }}
 {{- end }}
+{{- if or .Values.airflow.config.AIRFLOW__CORE__PLUGINS_FOLDER }}
+  {{ required "Don't define `airflow.config.AIRFLOW__CORE__PLUGINS_FOLDER`, it will be automatically set from `plugins.path`!" nil }}
+{{- end }}
 {{- if or (.Values.airflow.config.AIRFLOW__CELERY__BROKER_URL) (.Values.airflow.config.AIRFLOW__CELERY__BROKER_URL_CMD) }}
   {{ required "Don't define `airflow.config.AIRFLOW__CELERY__BROKER_URL`, it will be automatically set by the chart!" nil }}
 {{- end }}
@@ -129,6 +132,29 @@
   {{- end }}
   {{- if and (.Values.dags.gitSync.repo | lower | hasPrefix "git@github.com") (not .Values.dags.gitSync.sshSecret) }}
   {{ required "You must define `dags.gitSync.sshSecret` when using GitHub with SSH for `dags.gitSync.repo`!" nil }}
+  {{- end }}
+{{- end }}
+
+{{/* Checks for `plugins.persistence` */}}
+{{- if .Values.plugins.persistence.enabled }}
+  {{- if not (has .Values.plugins.persistence.accessMode (list "ReadOnlyMany" "ReadWriteMany")) }}
+  {{ required "The `plugins.persistence.accessMode` must be one of: [ReadOnlyMany, ReadWriteMany]!" nil }}
+  {{- end }}
+{{- end }}
+
+{{/* Checks for `plugins.gitSync` */}}
+{{- if .Values.plugins.gitSync.enabled }}
+  {{- if .Values.plugins.persistence.enabled }}
+  {{ required "If `plugins.gitSync.enabled=true`, then `persistence.enabled` must be disabled!" nil }}
+  {{- end }}
+  {{- if not .Values.plugins.gitSync.repo }}
+  {{ required "If `plugins.gitSync.enabled=true`, then `plugins.gitSync.repo` must be non-empty!" nil }}
+  {{- end }}
+  {{- if and (.Values.plugins.gitSync.sshSecret) (.Values.plugins.gitSync.httpSecret) }}
+  {{ required "At most, one of `plugins.gitSync.sshSecret` and `plugins.gitSync.httpSecret` can be defined!" nil }}
+  {{- end }}
+  {{- if and (.Values.plugins.gitSync.repo | lower | hasPrefix "git@github.com") (not .Values.plugins.gitSync.sshSecret) }}
+  {{ required "You must define `plugins.gitSync.sshSecret` when using GitHub with SSH for `plugins.gitSync.repo`!" nil }}
   {{- end }}
 {{- end }}
 

--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -119,6 +119,7 @@ data:
   ## Airflow Configs (General)
   ## ================
   AIRFLOW__CORE__DAGS_FOLDER: {{ include "airflow.dags.path" . | b64enc | quote }}
+  AIRFLOW__CORE__PLUGINS_FOLDER: {{ include "airflow.plugins.path" . | b64enc | quote }}
   AIRFLOW__CORE__EXECUTOR: {{ .Values.airflow.executor | toString | b64enc | quote }}
   {{- if .Values.airflow.fernetKey }}
   AIRFLOW__CORE__FERNET_KEY: {{ .Values.airflow.fernetKey | toString | b64enc | quote }}

--- a/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
@@ -82,9 +82,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
@@ -107,9 +110,12 @@ spec:
             - name: scripts
               mountPath: /mnt/scripts
               readOnly: true
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
         {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.dags_git_sync" . | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" . | indent 8 }}
         {{- end }}
       volumes:
         {{- $volumes | indent 8 }}

--- a/charts/airflow/templates/db-migrations/db-migrations-job.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-job.yaml
@@ -76,9 +76,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -86,9 +86,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -151,9 +154,12 @@ spec:
           volumeMounts:
             {{- $volumeMounts | indent 12 }}
           {{- end }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
         {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.dags_git_sync" . | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" . | indent 8 }}
         {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -94,8 +94,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -207,9 +211,13 @@ spec:
               readOnly: true
             {{- end }}
           {{- end }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
         {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.dags_git_sync" . | indent 8 }}
         {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" . | indent 8 }}
+        {{- end }}          
         {{- if .Values.scheduler.logCleanup.enabled }}
         {{- $lc_resources := .Values.scheduler.logCleanup.resources }}
         {{- $lc_retention_min := .Values.scheduler.logCleanup.retentionMinutes }}

--- a/charts/airflow/templates/sync/sync-connections-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-connections-deployment.yaml
@@ -82,9 +82,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -113,9 +116,12 @@ spec:
               mountPath: "/mnt/templates"
               readOnly: true
             {{- end }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
         {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.dags_git_sync" . | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" . | indent 8 }}
         {{- end }}
       volumes:
         {{- $volumes | indent 8 }}

--- a/charts/airflow/templates/sync/sync-connections-job.yaml
+++ b/charts/airflow/templates/sync/sync-connections-job.yaml
@@ -76,9 +76,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}

--- a/charts/airflow/templates/sync/sync-pools-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-pools-deployment.yaml
@@ -82,9 +82,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -108,9 +111,12 @@ spec:
             - name: scripts
               mountPath: /mnt/scripts
               readOnly: true
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
         {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.dags_git_sync" . | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" . | indent 8 }}
         {{- end }}
       volumes:
         {{- $volumes | indent 8 }}

--- a/charts/airflow/templates/sync/sync-pools-job.yaml
+++ b/charts/airflow/templates/sync/sync-pools-job.yaml
@@ -76,9 +76,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}

--- a/charts/airflow/templates/sync/sync-users-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-users-deployment.yaml
@@ -82,9 +82,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -113,10 +116,13 @@ spec:
               mountPath: "/mnt/templates"
               readOnly: true
             {{- end }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
         {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.dags_git_sync" . | indent 8 }}
         {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" . | indent 8 }}
+        {{- end }}            
       volumes:
         {{- $volumes | indent 8 }}
         - name: scripts

--- a/charts/airflow/templates/sync/sync-users-job.yaml
+++ b/charts/airflow/templates/sync/sync-users-job.yaml
@@ -76,9 +76,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}

--- a/charts/airflow/templates/sync/sync-variables-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-variables-deployment.yaml
@@ -82,9 +82,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -113,9 +116,12 @@ spec:
               mountPath: "/mnt/templates"
               readOnly: true
             {{- end }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
         {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.dags_git_sync" . | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" . | indent 8 }}
         {{- end }}
       volumes:
         {{- $volumes | indent 8 }}

--- a/charts/airflow/templates/sync/sync-variables-job.yaml
+++ b/charts/airflow/templates/sync/sync-variables-job.yaml
@@ -76,9 +76,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -86,8 +86,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -147,8 +151,12 @@ spec:
           volumeMounts:
             {{- $volumeMounts | indent 12 }}
           {{- end }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
         {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.dags_git_sync" . | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" . | indent 8 }}
         {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -147,6 +147,7 @@ spec:
               mountPath: /opt/airflow/webserver_config.py
               subPath: webserver_config.py
               readOnly: true
+            {{- end }}              
         ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
         {{- if .Values.dags.gitSync.enabled }}
         {{- include "airflow.container.dags_git_sync" . | indent 8 }}

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -88,8 +88,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -143,9 +147,12 @@ spec:
               mountPath: /opt/airflow/webserver_config.py
               subPath: webserver_config.py
               readOnly: true
-            {{- end }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
         {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.dags_git_sync" . | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" . | indent 8 }}
         {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -91,8 +91,12 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
+        {{- if .Values.dags.gitSync.enabled }}        
+        {{- include "airflow.container.dags_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -168,8 +172,12 @@ spec:
           volumeMounts:
             {{- $volumeMounts | indent 12 }}
           {{- end }}
+        ## Differentiate git-sync for both dags and plugins, so "dags" and "airflow plugins" can be pulled from separate repositories
         {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.dags_git_sync" . | indent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.gitSync.enabled }}
+        {{- include "airflow.container.plugins_git_sync" . | indent 8 }}
         {{- end }}
         {{- if .Values.workers.logCleanup.enabled }}
         {{- $lc_resources := .Values.workers.logCleanup.resources }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -2388,3 +2388,4 @@ prometheusRule:
   ## - docs for alerting rules: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
   ##
   groups: []
+  

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -2388,4 +2388,3 @@ prometheusRule:
   ## - docs for alerting rules: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
   ##
   groups: []
-  

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -281,7 +281,8 @@ airflow:
   ## FILE | pod_template.yaml
   ########################################
   ## - generates a file for `AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE`
-  ## - the `dags.gitSync` values will create a git-sync init-container in the pod
+  ## - the `dags.gitSync` values will create a dags-git-sync init-container in the pod
+  ## - the `plugins.gitSync` values will create a plugins-git-sync init-container in the pod
   ## - the `airflow.extraPipPackages` will NOT be installed
   ##
   kubernetesPodTemplate:
@@ -917,7 +918,8 @@ workers:
     minAvailable: ""
 
   ## configs for the HorizontalPodAutoscaler of the worker Pods
-  ## - [WARNING] if using git-sync, ensure `dags.gitSync.resources` is set
+  ## - [WARNING] if using dags-git-sync, ensure `dags.gitSync.resources` is set
+  ## - [WARNING] if using plugins-git-sync, ensure `plugins.gitSync.resources` is set
   ## - [WARNING] if using worker log-cleanup, ensure `workers.logCleanup.resources` is set
   ##
   ## ____ EXAMPLE _______________
@@ -1431,6 +1433,145 @@ dags:
     sshSecret: ""
 
     ## the key in `dags.gitSync.sshSecret` with your ssh-key file
+    ##
+    sshSecretKey: id_rsa
+
+    ## the string value of a "known_hosts" file (for SSH only)
+    ## - [WARNING] known_hosts verification will be disabled if left empty, making you more
+    ##   vulnerable to repo spoofing attacks
+    ##
+    ## ____ EXAMPLE _______________
+    ##   sshKnownHosts: |-
+    ##     <HOST_NAME> ssh-rsa <HOST_KEY>
+    ##
+    sshKnownHosts: ""
+
+    ## the number of consecutive failures allowed before aborting
+    ##  - the first sync must succeed
+    ##  - a value of -1 will retry forever after the initial sync
+    ##
+    maxFailures: 0
+
+###################################
+## CONFIG | Airflow Plugins
+###################################
+plugins:
+  ## the airflow plugins folder
+  ##
+  path: /opt/airflow/plugins
+
+  ## configs for the plugins PVC
+  ##
+  persistence:
+    ## if a persistent volume is mounted at `plugins.path`
+    ##
+    enabled: false
+
+    ## the name of an existing PVC to use
+    ##
+    existingClaim: ""
+
+    ## sub-path under `plugins.persistence.existingClaim` to use
+    ##
+    subPath: ""
+
+    ## the name of the StorageClass used by the PVC
+    ## - if set to "", then `PersistentVolumeClaim/spec.storageClassName` is omitted
+    ## - if set to "-", then `PersistentVolumeClaim/spec.storageClassName` is set to ""
+    ##
+    storageClass: ""
+
+    ## the access mode of the PVC
+    ## - [WARNING] must be "ReadOnlyMany" or "ReadWriteMany" otherwise airflow pods will fail to start
+    ##
+    accessMode: ReadOnlyMany
+
+    ## the size of PVC to request
+    ##
+    size: 1Gi
+
+  ## configs for the git-sync sidecar (https://github.com/kubernetes/git-sync)
+  ##
+  gitSync:
+    ## if the git-sync sidecar container is enabled
+    ##
+    enabled: false
+
+    ## the git-sync container image
+    ##
+    image:
+      repository: k8s.gcr.io/git-sync/git-sync
+      tag: v3.5.0
+      pullPolicy: IfNotPresent
+      uid: 65533
+      gid: 65533
+
+    ## resource requests/limits for the git-sync container
+    ## - spec for ResourceRequirements:
+    ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+    ##
+    resources: {}
+
+    ## the url of the git repo
+    ##
+    ## ____ EXAMPLE _______________
+    ##   # https git repo
+    ##   repo: "https://github.com/USERNAME/REPOSITORY.git"
+    ##
+    ## ____ EXAMPLE _______________
+    ##   # ssh git repo
+    ##   repo: "git@github.com:USERNAME/REPOSITORY.git"
+    ##
+    repo: ""
+
+    ## the sub-path within your repo where plugins are located
+    ## - only plugins under this path within your repo will be seen by airflow,
+    ##   (note, the full repo will still be cloned)
+    ##
+    repoSubPath: ""
+
+    ## the git branch to check out
+    ##
+    branch: master
+
+    ## the git revision (tag or hash) to check out
+    ##
+    revision: HEAD
+
+    ## shallow clone with a history truncated to the specified number of commits
+    ##
+    depth: 1
+
+    ## the number of seconds between syncs
+    ##
+    syncWait: 60
+
+    ## the max number of seconds allowed for a complete sync
+    ##
+    syncTimeout: 120
+
+    ## the git submodule behavior
+    ## - allowed values: "recursive", "shallow", "off"
+    ##
+    submodules: recursive
+
+    ## the name of a pre-created Secret with git http credentials
+    ##
+    httpSecret: ""
+
+    ## the key in `plugins.gitSync.httpSecret` with your git username
+    ##
+    httpSecretUsernameKey: username
+
+    ## the key in `plugins.gitSync.httpSecret` with your git password/token
+    ##
+    httpSecretPasswordKey: password
+
+    ## the name of a pre-created Secret with git ssh credentials
+    ##
+    sshSecret: ""
+
+    ## the key in `plugins.gitSync.sshSecret` with your ssh-key file
     ##
     sshSecretKey: id_rsa
 


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- fixes #166 

## What does your PR do?

This PR makes the following changes...

Adds `plugins.*` values with the same structure as in the `dags.*` variables, in order to differentiate git-sync for both "dags" and "plugins", so "dags" and "airflow plugins" can be pulled from separate repositories.

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [X] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [X] CHANGELOG.md updated