### PR TITLE
fix: liveness probes airflow 2.6.0 support

### DIFF
--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -140,7 +140,8 @@ spec:
                   os.environ["AIRFLOW__LOGGING__LOGGING_LEVEL"] = "ERROR"
                   {{- end }}
 
-                  from airflow.jobs.scheduler_job import SchedulerJob
+                  from airflow.jobs.job import Job
+                  from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
                   from airflow.utils.db import create_session
                   from airflow.utils.net import get_hostname
                   {{- if .Values.scheduler.livenessProbe.taskCreationCheck.enabled }}
@@ -155,9 +156,10 @@ spec:
                       # ensure the SchedulerJob with most recent heartbeat for this `hostname` is alive
                       hostname = get_hostname()
                       scheduler_job = session \
-                          .query(SchedulerJob) \
+                          .query(Job) \
+                          .filter_by(job_type=SchedulerJobRunner.job_type) \
                           .filter_by(hostname=hostname) \
-                          .order_by(SchedulerJob.latest_heartbeat.desc()) \
+                          .order_by(Job.latest_heartbeat.desc()) \
                           .limit(1) \
                           .first()
                       if (scheduler_job is not None) and scheduler_job.is_alive():

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -140,13 +140,25 @@ spec:
                   os.environ["AIRFLOW__LOGGING__LOGGING_LEVEL"] = "ERROR"
                   {{- end }}
 
-                  from airflow.jobs.job import Job
-                  from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
+                  # check which version of airflow we are running to determine which classes to import
+                  import airflow
+                  from packaging import version
+                  useNewProbe = version.parse(airflow.__version__) >= version.parse("2.6.0")
+
+                  if useNewProbe:
+                    from airflow.jobs.job import Job
+                    from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
+                  else:
+                    from airflow.jobs.scheduler_job import SchedulerJob
+
                   from airflow.utils.db import create_session
                   from airflow.utils.net import get_hostname
                   {{- if .Values.scheduler.livenessProbe.taskCreationCheck.enabled }}
-                  from airflow.jobs.local_task_job import LocalTaskJob
-                  from airflow.utils import timezone
+                  if useNewProbe:
+                    from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
+                  else:
+                    from airflow.jobs.local_task_job import LocalTaskJob
+                    from airflow.utils import timezone
                   {{- end }}
 
                   with create_session() as session:
@@ -155,13 +167,21 @@ spec:
                       ########################
                       # ensure the SchedulerJob with most recent heartbeat for this `hostname` is alive
                       hostname = get_hostname()
-                      scheduler_job = session \
-                          .query(Job) \
-                          .filter_by(job_type=SchedulerJobRunner.job_type) \
-                          .filter_by(hostname=hostname) \
-                          .order_by(Job.latest_heartbeat.desc()) \
-                          .limit(1) \
-                          .first()
+                      if useNewProbe:
+                        scheduler_job = session \
+                            .query(Job) \
+                            .filter_by(job_type=SchedulerJobRunner.job_type) \
+                            .filter_by(hostname=hostname) \
+                            .order_by(Job.latest_heartbeat.desc()) \
+                            .limit(1) \
+                            .first()
+                      else:
+                        scheduler_job = session \
+                            .query(SchedulerJob) \
+                            .filter_by(hostname=hostname) \
+                            .order_by(SchedulerJob.latest_heartbeat.desc()) \
+                            .limit(1) \
+                            .first()
                       if (scheduler_job is not None) and scheduler_job.is_alive():
                           pass
                       else:
@@ -184,11 +204,19 @@ spec:
                       if (timezone.utcnow() - scheduler_job.start_date).total_seconds() > min_scheduler_age:
                           # ensure the most recent LocalTaskJob had a start_date in the last `task_job_threshold` seconds
                           task_job_threshold = {{ $task_job_threshold }}
-                          task_job = session \
-                              .query(LocalTaskJob) \
-                              .order_by(LocalTaskJob.id.desc()) \
-                              .limit(1) \
-                              .first()
+                          if useNewProbe:
+                            task_job = session \
+                                .query(Job) \
+                                .filter_by(job_type=LocalTaskJobRunner.job_type) \
+                                .order_by(Job.latest_heartbeat.desc()) \
+                                .limit(1) \
+                                .first()
+                          else:
+                            task_job = session \
+                                .query(LocalTaskJob) \
+                                .order_by(LocalTaskJob.id.desc()) \
+                                .limit(1) \
+                                .first()
                           if task_job is not None:
                               if (timezone.utcnow() - task_job.start_date).total_seconds() < task_job_threshold:
                                   pass

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -125,7 +125,8 @@ spec:
                   # suppress logs triggered from importing airflow packages
                   os.environ["AIRFLOW__LOGGING__LOGGING_LEVEL"] = "ERROR"
 
-                  from airflow.jobs.triggerer_job import TriggererJob
+                  from airflow.jobs.job import Job
+                  from airflow.jobs.triggerer_job_runner import TriggererJobRunner
                   from airflow.utils.db import create_session
                   from airflow.utils.net import get_hostname
 
@@ -133,9 +134,10 @@ spec:
                       # ensure the TriggererJob with most recent heartbeat for this `hostname` is alive
                       hostname = get_hostname()
                       triggerer_job = session \
-                          .query(TriggererJob) \
+                          .query(Job) \
+                          .filter_by(job_type=TriggererJobRunner.job_type) \
                           .filter_by(hostname=hostname) \
-                          .order_by(TriggererJob.latest_heartbeat.desc()) \
+                          .order_by(Job.latest_heartbeat.desc()) \
                           .limit(1) \
                           .first()
                       if (triggerer_job is not None) and triggerer_job.is_alive():

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -125,21 +125,38 @@ spec:
                   # suppress logs triggered from importing airflow packages
                   os.environ["AIRFLOW__LOGGING__LOGGING_LEVEL"] = "ERROR"
 
-                  from airflow.jobs.job import Job
-                  from airflow.jobs.triggerer_job_runner import TriggererJobRunner
+                  # check which version of airflow we are running to determine which classes to import
+                  import airflow
+                  from packaging import version
+                  useNewProbe = version.parse(airflow.__version__) >= version.parse("2.6.0")
+
+                  if useNewProbe:
+                    from airflow.jobs.job import Job
+                    from airflow.jobs.triggerer_job_runner import TriggererJobRunner
+                  else:
+                    from airflow.jobs.triggerer_job import TriggererJob
+
                   from airflow.utils.db import create_session
                   from airflow.utils.net import get_hostname
 
                   with create_session() as session:
                       # ensure the TriggererJob with most recent heartbeat for this `hostname` is alive
                       hostname = get_hostname()
-                      triggerer_job = session \
-                          .query(Job) \
-                          .filter_by(job_type=TriggererJobRunner.job_type) \
-                          .filter_by(hostname=hostname) \
-                          .order_by(Job.latest_heartbeat.desc()) \
-                          .limit(1) \
-                          .first()
+                      if useNewProbe:
+                        triggerer_job = session \
+                            .query(Job) \
+                            .filter_by(job_type=TriggererJobRunner.job_type) \
+                            .filter_by(hostname=hostname) \
+                            .order_by(Job.latest_heartbeat.desc()) \
+                            .limit(1) \
+                            .first()
+                      else:
+                        triggerer_job = session \
+                            .query(TriggererJob) \
+                            .filter_by(hostname=hostname) \
+                            .order_by(TriggererJob.latest_heartbeat.desc()) \
+                            .limit(1) \
+                            .first()
                       if (triggerer_job is not None) and triggerer_job.is_alive():
                           pass
                       else:


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- fixes #737 


## What does your PR do?

This PR updates the liveness probes for the scheduler and triggerer so they are compatible with Airflow 2.6.0. Not sure how best to deal with backwards compatibility though so this PR still requires some work. I assume there are some ways backwards compatibility with airflow versions that already exist, so if those can be recommended I can update this PR.


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [ ] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated