### PR TITLE
Add http based readiness and liveness probes to Scheduler

### DIFF
--- a/charts/airflow/docs/faq/monitoring/scheduler-liveness-probe.md
+++ b/charts/airflow/docs/faq/monitoring/scheduler-liveness-probe.md
@@ -49,37 +49,6 @@ scheduler:
 > - https://github.com/apache/airflow/issues/7935 - patched in airflow `2.0.2`
 > - https://github.com/apache/airflow/issues/15938 - patched in airflow `2.1.1`
 
-## Scheduler "Task Creation Check"
-
-The liveness probe can additionally check if the Scheduler is creating new [tasks](https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html) as an indication of its health.
-This check works by ensuring that the most recent `LocalTaskJob` had a `start_date` no more than `scheduler.livenessProbe.taskCreationCheck.thresholdSeconds` seconds ago.
-
-> 🟦 __Tip__ 🟦
->
-> The "Task Creation Check" is currently disabled by default, it can be enabled with `scheduler.livenessProbe.taskCreationCheck.enabled`.
-
-Here is an overview of the `scheduler.livenessProbe.taskCreationCheck.*` values:
-
-```yaml
-scheduler:
-  livenessProbe:
-    enabled: true
-    
-    taskCreationCheck:
-      ## if the task creation check is enabled
-      enabled: true
-
-      ## the maximum number of seconds since the start_date of the most recent LocalTaskJob
-      ## WARNING: must be AT LEAST equal to your shortest DAG schedule_interval
-      ## WARNING: DummyOperator tasks will NOT be seen by this probe
-      thresholdSeconds: 300
-      
-      ## minimum number of seconds the scheduler must have run before the task creation check begins
-      ## WARNING: must be long enough for the scheduler to boot and create a task
-      ##
-      schedulerAgeBeforeCheck: 180
-```
-
 > 🟦 __Tip__ 🟦
 >
 > You might use the following `canary_dag` DAG definition to run a small task every __300 seconds__ (5 minutes).

--- a/charts/airflow/examples/google-gke/custom-values.yaml
+++ b/charts/airflow/examples/google-gke/custom-values.yaml
@@ -149,12 +149,8 @@ scheduler:
   livenessProbe:
     enabled: true
 
-    ## configs for an additional check that ensures tasks are being created by the scheduler
-    ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/monitoring/scheduler-liveness-probe.md
-    taskCreationCheck:
-      enabled: false
-      thresholdSeconds: 300
-      schedulerAgeBeforeCheck: 180
+  readinessProbe:
+    enabled: true
 
 ###################################
 ## COMPONENT | Airflow Webserver

--- a/charts/airflow/examples/minikube/custom-values.yaml
+++ b/charts/airflow/examples/minikube/custom-values.yaml
@@ -113,12 +113,8 @@ scheduler:
   livenessProbe:
     enabled: true
 
-    ## configs for an additional check that ensures tasks are being created by the scheduler
-    ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/monitoring/scheduler-liveness-probe.md
-    taskCreationCheck:
-      enabled: false
-      thresholdSeconds: 300
-      schedulerAgeBeforeCheck: 180
+  readinessProble:
+    enabled: true
 
 ###################################
 ## COMPONENT | Airflow Webserver

--- a/charts/airflow/sample-values-CeleryExecutor.yaml
+++ b/charts/airflow/sample-values-CeleryExecutor.yaml
@@ -93,12 +93,8 @@ scheduler:
   livenessProbe:
     enabled: true
 
-    ## configs for an additional check that ensures tasks are being created by the scheduler
-    ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/monitoring/scheduler-liveness-probe.md
-    taskCreationCheck:
-      enabled: false
-      thresholdSeconds: 300
-      schedulerAgeBeforeCheck: 180
+  readinessProbe:
+    enabled: true
 
 ###################################
 ## COMPONENT | Airflow Webserver

--- a/charts/airflow/sample-values-CeleryKubernetesExecutor.yaml
+++ b/charts/airflow/sample-values-CeleryKubernetesExecutor.yaml
@@ -121,12 +121,8 @@ scheduler:
   livenessProbe:
     enabled: true
 
-    ## configs for an additional check that ensures tasks are being created by the scheduler
-    ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/monitoring/scheduler-liveness-probe.md
-    taskCreationCheck:
-      enabled: false
-      thresholdSeconds: 300
-      schedulerAgeBeforeCheck: 180
+  readinessProbe:
+    enabled: true
 
 ###################################
 ## COMPONENT | Airflow Webserver

--- a/charts/airflow/sample-values-KubernetesExecutor.yaml
+++ b/charts/airflow/sample-values-KubernetesExecutor.yaml
@@ -121,12 +121,8 @@ scheduler:
   livenessProbe:
     enabled: true
 
-    ## configs for an additional check that ensures tasks are being created by the scheduler
-    ## [FAQ] https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/monitoring/scheduler-liveness-probe.md
-    taskCreationCheck:
-      enabled: false
-      thresholdSeconds: 300
-      schedulerAgeBeforeCheck: 180
+  readinessProbe:
+    enabled: true
 
 ###################################
 ## COMPONENT | Airflow Webserver

--- a/charts/airflow/templates/NOTES.txt
+++ b/charts/airflow/templates/NOTES.txt
@@ -114,12 +114,6 @@
 {{- $scheduler_livenessProbe_warning = true }}
 {{- end }}
 
-{{- /* if we show the scheduler livenessProbe taskCreationCheck warning */ -}}
-{{- $scheduler_livenessProbe_taskCreationCheck_warning := false }}
-{{- if and (.Values.scheduler.livenessProbe.enabled) (not .Values.scheduler.livenessProbe.taskCreationCheck.enabled) }}
-{{- $scheduler_livenessProbe_taskCreationCheck_warning = true }}
-{{- end }}
-
 ========================================================================
 Thanks for deploying Apache Airflow with the User-Community Helm Chart!
 
@@ -218,11 +212,6 @@ Use these commands to port-forward the Services to your localhost:
 {{- if $scheduler_livenessProbe_warning }}
 [MEDIUM] the scheduler liveness probe is disabled, the scheduler may not be restarted if it becomes unhealthy!
   * HELP: enable the probe with `scheduler.livenessProbe.enabled`
-{{ end }}
-
-{{- if $scheduler_livenessProbe_taskCreationCheck_warning }}
-[MEDIUM] the scheduler "task creation check" is disabled, the scheduler may not be restarted if it deadlocks!
-  * HELP: configure the check with `scheduler.livenessProbe.taskCreationCheck.*`
 {{ end }}
 
 {{- end }}

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -110,6 +110,10 @@ spec:
           envFrom:
             {{- include "airflow.envFrom" . | indent 12 }}
           env:
+            - name: AIRFLOW__SCHEDULER__ENABLE_HEALTH_CHECK
+              value: "True"
+            - name: AIRFLOW__SCHEDULER__SCHEDULER_HEALTH_CHECK_SERVER_PORT
+              value: "8974"
             {{- include "airflow.env" . | indent 12 }}
           command:
             {{- include "airflow.command" . | indent 12 }}
@@ -117,85 +121,25 @@ spec:
             - "bash"
             - "-c"
             - "exec airflow scheduler -n {{ .Values.scheduler.numRuns }}"
+          {{- if .Values.scheduler.readinessProbe.enabled }}
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.scheduler.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.scheduler.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.scheduler.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.scheduler.readinessProbe.timeoutSeconds }}
+            httpGet:
+              port: 8974
+              path: /health
+          {{- end }}
           {{- if .Values.scheduler.livenessProbe.enabled }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.scheduler.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.scheduler.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.scheduler.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.scheduler.livenessProbe.timeoutSeconds }}
-            exec:
-              command:
-                {{- include "airflow.command" . | indent 16 }}
-                - "python"
-                - "-Wignore"
-                - "-c"
-                - |
-                  import os
-                  import sys
-
-                  # suppress logs triggered from importing airflow packages
-                  {{- if .Values.airflow.legacyCommands }}
-                  os.environ["AIRFLOW__CORE__LOGGING_LEVEL"] = "ERROR"
-                  {{- else }}
-                  os.environ["AIRFLOW__LOGGING__LOGGING_LEVEL"] = "ERROR"
-                  {{- end }}
-
-                  from airflow.jobs.scheduler_job import SchedulerJob
-                  from airflow.utils.db import create_session
-                  from airflow.utils.net import get_hostname
-                  {{- if .Values.scheduler.livenessProbe.taskCreationCheck.enabled }}
-                  from airflow.jobs.local_task_job import LocalTaskJob
-                  from airflow.utils import timezone
-                  {{- end }}
-
-                  with create_session() as session:
-                      ########################
-                      # heartbeat check
-                      ########################
-                      # ensure the SchedulerJob with most recent heartbeat for this `hostname` is alive
-                      hostname = get_hostname()
-                      scheduler_job = session \
-                          .query(SchedulerJob) \
-                          .filter_by(hostname=hostname) \
-                          .order_by(SchedulerJob.latest_heartbeat.desc()) \
-                          .limit(1) \
-                          .first()
-                      if (scheduler_job is not None) and scheduler_job.is_alive():
-                          pass
-                      else:
-                          sys.exit(f"The SchedulerJob (id={scheduler_job.id}) for hostname '{hostname}' is not alive")
-                      {{- if .Values.scheduler.livenessProbe.taskCreationCheck.enabled }}
-                      {{- $min_scheduler_age := .Values.scheduler.livenessProbe.taskCreationCheck.schedulerAgeBeforeCheck }}
-                      {{- if not (or (typeIs "float64" $min_scheduler_age) (typeIs "int64" $min_scheduler_age)) }}
-                      {{- /* the type of a number could be float64 or int64 depending on how it was set (values.yaml, or --set) */ -}}
-                      {{ required (printf "`scheduler.livenessProbe.taskCreationCheck.schedulerAgeBeforeCheck` must be int-type, but got %s!" (typeOf $min_scheduler_age)) nil }}
-                      {{- end }}
-                      {{- $task_job_threshold := .Values.scheduler.livenessProbe.taskCreationCheck.thresholdSeconds }}
-                      {{- if not (or (typeIs "float64" $task_job_threshold) (typeIs "int64" $task_job_threshold)) }}
-                      {{- /* the type of a number could be float64 or int64 depending on how it was set (values.yaml, or --set) */ -}}
-                      {{ required (printf "`scheduler.livenessProbe.taskCreationCheck.thresholdSeconds` must be int-type, but got %s!" (typeOf $task_job_threshold)) nil }}
-                      {{- end }}
-                      ########################
-                      # task creation check
-                      ########################
-                      min_scheduler_age = {{ $min_scheduler_age }}
-                      if (timezone.utcnow() - scheduler_job.start_date).total_seconds() > min_scheduler_age:
-                          # ensure the most recent LocalTaskJob had a start_date in the last `task_job_threshold` seconds
-                          task_job_threshold = {{ $task_job_threshold }}
-                          task_job = session \
-                              .query(LocalTaskJob) \
-                              .order_by(LocalTaskJob.id.desc()) \
-                              .limit(1) \
-                              .first()
-                          if task_job is not None:
-                              if (timezone.utcnow() - task_job.start_date).total_seconds() < task_job_threshold:
-                                  pass
-                              else:
-                                  sys.exit(
-                                      f"The most recent LocalTaskJob (id={task_job.id}, dag_id={task_job.dag_id}) "
-                                      f"started over {task_job_threshold} seconds ago"
-                                  )
-                      {{- end }}
+            httpGet:
+              port: 8974
+              path: /health
           {{- end }}
           {{- if or ($volumeMounts) (include "airflow.executor.kubernetes_like" .) }}
           volumeMounts:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -609,9 +609,6 @@ scheduler:
   numRuns: -1
 
   ## configs for the scheduler Pods' liveness probe
-  ## - "unhealthy" means the SchedulerJob has not had a heartbeat for
-  ##   AIRFLOW__SCHEDULER__SCHEDULER_HEALTH_CHECK_THRESHOLD seconds
-  ## - `periodSeconds` x `failureThreshold` = max seconds a scheduler can be in an "unhealthy" state
   ##
   livenessProbe:
     enabled: true
@@ -620,28 +617,15 @@ scheduler:
     timeoutSeconds: 60
     failureThreshold: 5
 
-    ## configs for an additional check that ensures tasks are being created by the scheduler
-    ## - this check works by ensuring that the most recent LocalTaskJob had a `start_date` no more than
-    ##   `taskCreationCheck.thresholdSeconds` seconds ago
-    ## - this check is useful because the scheduler can deadlock with a heartbeat, but not be scheduling new tasks:
-    ##   https://github.com/apache/airflow/issues/7935 - patched in airflow `2.0.2`
-    ##   https://github.com/apache/airflow/issues/15938 - patched in airflow `2.1.1`
-    ##
-    taskCreationCheck:
-      ## if the task creation check is enabled
-      ##
-      enabled: false
 
-      ## the maximum number of seconds since the start_date of the most recent LocalTaskJob
-      ## - [WARNING] must be AT LEAST equal to your shortest DAG schedule_interval
-      ## - [WARNING] DummyOperator tasks will NOT be seen by this probe
-      ##
-      thresholdSeconds: 300
-
-      ## minimum number of seconds the scheduler must have run before the task creation check begins
-      ## - [WARNING] must be long enough for the scheduler to boot and create a task
-      ##
-      schedulerAgeBeforeCheck: 180
+  ## configs for the scheduler Pods' readiness probe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
 
   ## extra pip packages to install in the scheduler Pods
   ##


### PR DESCRIPTION
## Fixes
https://github.com/airflow-helm/charts/issues/737

## What does your PR do?

The current scheduler health check includes python code that changes with Airflow version and with the recent 2.6.0 release there are more changes needed to the health check code.

Instead scheduler exposes a webserver that runs the exact same health check code and is maintained along with Airflow code. This change leverages the same webserver to perform readiness and liveness probes.

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [ ] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated