### PR TITLE
feat: add scrapeTimeout to prometheus serviceMonitor endpoint

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -535,7 +535,8 @@ Parameter | Description | Default
 `serviceMonitor.enabled` | if ServiceMonitor resources should be deployed | `false`
 `serviceMonitor.selector` | labels for ServiceMonitor, so that Prometheus can select it | `{ prometheus: "kube-prometheus" }`
 `serviceMonitor.path` | the ServiceMonitor web endpoint path | `/admin/metrics`
-`serviceMonitor.interval` | the ServiceMonitor web endpoint path | `30s`
+`serviceMonitor.interval` | the ServiceMonitor web endpoint interval | `30s`
+`serviceMonitor.scrapeTimeout` | the ServiceMonitor web endpoint scrape timeout | `10s`
 
 </details>
 

--- a/charts/airflow/templates/webserver/webserver-service-monitor.yaml
+++ b/charts/airflow/templates/webserver/webserver-service-monitor.yaml
@@ -22,4 +22,5 @@ spec:
     - port: web
       path: {{ .Values.serviceMonitor.path }}
       interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
 {{- end }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -2227,6 +2227,10 @@ serviceMonitor:
   ##
   interval: "30s"
 
+  ## the ServiceMonitor web endpoint scrape timeout
+  ##
+  scrapeTimeout: "10s"
+
 ###################################
 ## CONFIG | PrometheusRule (Prometheus Operator)
 ###################################


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- If metrics take longer than the current default of 10 seconds to scrape, no metrics are collected.
- To change this value, have to patch the service monitor or edit the yaml after each deployment.
- In my use case, the average scrape duration is 8 seconds and sometimes takes above 10 seconds leaving gaps in the metrics and I have to patch the service monitor with a scrape timeout set to 20 seconds.


## What does your PR do?

Give users the ability to edit the scrape timeout to their desired setting if needed, while keeping the default of 10 seconds. In the documentation, the  [endpoint scrape timeout](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint) is set to the prometheus [global scrape timeout](https://prometheus.io/docs/prometheus/latest/configuration/configuration/) of 10 seconds.


## Checklist

### For all Pull Requests

- [ ] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [ ] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [ ] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated