### PR TITLE
feat: add `topologySpreadConstraints` values

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -214,6 +214,7 @@ Parameter | Description | Default
 `airflow.pools` | a list airflow pools to create | `<see values.yaml>`
 `airflow.poolsUpdate` | if we create a Deployment to perpetually sync `airflow.pools` | `true`
 `airflow.defaultNodeSelector` | default nodeSelector for airflow Pods (is overridden by pod-specific values) | `{}`
+`airflow.defaultTopologySpreadConstraints` | default topologySpreadConstraints for airflow Pods (is overridden by pod-specific values) | `[]`
 `airflow.defaultAffinity` | default affinity configs for airflow Pods (is overridden by pod-specific values) | `{}`
 `airflow.defaultTolerations` | default toleration configs for airflow Pods (is overridden by pod-specific values) | `[]`
 `airflow.defaultSecurityContext` | default securityContext configs for Pods (is overridden by pod-specific values) | `{fsGroup: 0}`
@@ -241,6 +242,7 @@ Parameter | Description | Default
 `scheduler.replicas` | the number of scheduler Pods to run | `1`
 `scheduler.resources` | resource requests/limits for the scheduler Pods | `{}`
 `scheduler.nodeSelector` | the nodeSelector configs for the scheduler Pods | `{}`
+`scheduler.topologySpreadConstraints` | the topologySpreadConstraints configs for the scheduler Pods | `[]`
 `scheduler.affinity` | the affinity configs for the scheduler Pods | `{}`
 `scheduler.tolerations` | the toleration configs for the scheduler Pods | `[]`
 `scheduler.securityContext` | the security context for the scheduler Pods | `{}`
@@ -269,6 +271,7 @@ Parameter | Description | Default
 `web.replicas` | the number of web Pods to run | `1`
 `web.resources` | resource requests/limits for the airflow web pods | `{}`
 `web.nodeSelector` | the number of web Pods to run | `{}`
+`web.topologySpreadConstraints` | the topologySpreadConstraints configs for the web Pods | `[]`
 `web.affinity` | the affinity configs for the web Pods | `{}`
 `web.tolerations` | the toleration configs for the web Pods | `[]`
 `web.securityContext` | the security context for the web Pods | `{}`
@@ -296,6 +299,7 @@ Parameter | Description | Default
 `workers.replicas` | the number of workers Pods to run | `1`
 `workers.resources` | resource requests/limits for the airflow worker Pods | `{}`
 `workers.nodeSelector` | the nodeSelector configs for the worker Pods | `{}`
+`workers.topologySpreadConstraints` | the topologySpreadConstraints configs for the worker Pods | `[]`
 `workers.affinity` | the affinity configs for the worker Pods | `{}`
 `workers.tolerations` | the toleration configs for the worker Pods | `[]`
 `workers.securityContext` | the security context for the worker Pods | `{}`
@@ -325,6 +329,7 @@ Parameter | Description | Default
 `triggerer.replicas` | the number of triggerer Pods to run | `1`
 `triggerer.resources` | resource requests/limits for the airflow triggerer Pods | `{}`
 `triggerer.nodeSelector` | the nodeSelector configs for the triggerer Pods | `{}`
+`triggerer.topologySpreadConstraints` | the topologySpreadConstraints configs for the triggerer Pods | `[]`
 `triggerer.affinity` | the affinity configs for the triggerer Pods | `{}`
 `triggerer.tolerations` | the toleration configs for the triggerer Pods | `[]`
 `triggerer.securityContext` | the security context for the triggerer Pods | `{}`
@@ -350,6 +355,7 @@ Parameter | Description | Default
 `flower.enabled` | if the Flower UI should be deployed | `true`
 `flower.resources` | resource requests/limits for the flower Pods | `{}`
 `flower.nodeSelector` | the nodeSelector configs for the flower Pods | `{}`
+`flower.topologySpreadConstraints` | the topologySpreadConstraints configs for the flower Pods | `[]`
 `flower.affinity` | the affinity configs for the flower Pods | `{}`
 `flower.tolerations` | the toleration configs for the flower Pods | `[]`
 `flower.securityContext` | the security context for the flower Pods | `{}`
@@ -440,6 +446,7 @@ Parameter | Description | Default
 `pgbouncer.image.*` | configs for the pgbouncer container image | `<see values.yaml>`
 `pgbouncer.resources` | resource requests/limits for the pgbouncer Pods | `{}`
 `pgbouncer.nodeSelector` | the nodeSelector configs for the pgbouncer Pods | `{}`
+`pgbouncer.topologySpreadConstraints` | the topologySpreadConstraints configs for the pgbouncer Pods | `[]`
 `pgbouncer.affinity` | the affinity configs for the pgbouncer Pods | `{}`
 `pgbouncer.tolerations` | the toleration configs for the pgbouncer Pods | `[]`
 `pgbouncer.securityContext` | the security context for the pgbouncer Pods | `{}`

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -139,7 +139,7 @@ Please note, this chart is __independent__ from the official chart in the `apach
   - [`Mount Extra Persistent Volumes`](https://github.com/airflow-helm/charts/tree/main/charts/airflow/docs/faq/kubernetes/mount-persistent-volumes.md) <sup><sub>⭐</sub></sup>
   - [`Mount Files from Secrets/ConfigMaps`](https://github.com/airflow-helm/charts/tree/main/charts/airflow/docs/faq/kubernetes/mount-files.md) <a id="how-to-mount-secretsconfigmaps-as-files-on-workers"></a>
   - [`Mount Environment Variables from Secrets/ConfigMaps`](https://github.com/airflow-helm/charts/tree/main/charts/airflow/docs/faq/kubernetes/mount-environment-variables.md) <a id="how-to-create-airflow-variables"></a>
-  - [`Configure Pod Affinity/Selectors/Tolerations`](https://github.com/airflow-helm/charts/tree/main/charts/airflow/docs/faq/kubernetes/affinity-node-selectors-tolerations.md) <a id="how-to-use-pod-affinity-nodeselector-and-tolerations"></a>
+  - [`Configure Pod Affinity/Selectors/Tolerations/TopologySpreadConstraints`](https://github.com/airflow-helm/charts/tree/main/charts/airflow/docs/faq/kubernetes/affinity-node-selectors-tolerations.md) <a id="how-to-use-pod-affinity-nodeselector-and-tolerations"></a>
   - [`Include Extra Kubernetes Manifests`](https://github.com/airflow-helm/charts/tree/main/charts/airflow/docs/faq/kubernetes/extra-manifests.md) <a id="how-to-add-extra-manifests"></a>
 
 ## Examples
@@ -214,9 +214,9 @@ Parameter | Description | Default
 `airflow.pools` | a list airflow pools to create | `<see values.yaml>`
 `airflow.poolsUpdate` | if we create a Deployment to perpetually sync `airflow.pools` | `true`
 `airflow.defaultNodeSelector` | default nodeSelector for airflow Pods (is overridden by pod-specific values) | `{}`
-`airflow.defaultTopologySpreadConstraints` | default topologySpreadConstraints for airflow Pods (is overridden by pod-specific values) | `[]`
 `airflow.defaultAffinity` | default affinity configs for airflow Pods (is overridden by pod-specific values) | `{}`
 `airflow.defaultTolerations` | default toleration configs for airflow Pods (is overridden by pod-specific values) | `[]`
+`airflow.defaultTopologySpreadConstraints` | default topologySpreadConstraints for airflow Pods (is overridden by pod-specific values) | `[]`
 `airflow.defaultSecurityContext` | default securityContext configs for Pods (is overridden by pod-specific values) | `{fsGroup: 0}`
 `airflow.podAnnotations` | extra annotations for airflow Pods | `{}`
 `airflow.extraPipPackages` | extra pip packages to install in airflow Pods | `[]`
@@ -242,9 +242,9 @@ Parameter | Description | Default
 `scheduler.replicas` | the number of scheduler Pods to run | `1`
 `scheduler.resources` | resource requests/limits for the scheduler Pods | `{}`
 `scheduler.nodeSelector` | the nodeSelector configs for the scheduler Pods | `{}`
-`scheduler.topologySpreadConstraints` | the topologySpreadConstraints configs for the scheduler Pods | `[]`
 `scheduler.affinity` | the affinity configs for the scheduler Pods | `{}`
 `scheduler.tolerations` | the toleration configs for the scheduler Pods | `[]`
+`scheduler.topologySpreadConstraints` | the topologySpreadConstraints configs for the scheduler Pods | `[]`
 `scheduler.securityContext` | the security context for the scheduler Pods | `{}`
 `scheduler.labels` | labels for the scheduler Deployment | `{}`
 `scheduler.podLabels` | Pod labels for the scheduler Deployment | `{}`
@@ -271,9 +271,9 @@ Parameter | Description | Default
 `web.replicas` | the number of web Pods to run | `1`
 `web.resources` | resource requests/limits for the airflow web pods | `{}`
 `web.nodeSelector` | the number of web Pods to run | `{}`
-`web.topologySpreadConstraints` | the topologySpreadConstraints configs for the web Pods | `[]`
 `web.affinity` | the affinity configs for the web Pods | `{}`
 `web.tolerations` | the toleration configs for the web Pods | `[]`
+`web.topologySpreadConstraints` | the topologySpreadConstraints configs for the web Pods | `[]`
 `web.securityContext` | the security context for the web Pods | `{}`
 `web.labels` | labels for the web Deployment | `{}`
 `web.podLabels` | Pod labels for the web Deployment | `{}`
@@ -299,9 +299,9 @@ Parameter | Description | Default
 `workers.replicas` | the number of workers Pods to run | `1`
 `workers.resources` | resource requests/limits for the airflow worker Pods | `{}`
 `workers.nodeSelector` | the nodeSelector configs for the worker Pods | `{}`
-`workers.topologySpreadConstraints` | the topologySpreadConstraints configs for the worker Pods | `[]`
 `workers.affinity` | the affinity configs for the worker Pods | `{}`
 `workers.tolerations` | the toleration configs for the worker Pods | `[]`
+`workers.topologySpreadConstraints` | the topologySpreadConstraints configs for the worker Pods | `[]`
 `workers.securityContext` | the security context for the worker Pods | `{}`
 `workers.labels` | labels for the worker StatefulSet | `{}`
 `workers.podLabels` | Pod labels for the worker StatefulSet | `{}`
@@ -329,9 +329,9 @@ Parameter | Description | Default
 `triggerer.replicas` | the number of triggerer Pods to run | `1`
 `triggerer.resources` | resource requests/limits for the airflow triggerer Pods | `{}`
 `triggerer.nodeSelector` | the nodeSelector configs for the triggerer Pods | `{}`
-`triggerer.topologySpreadConstraints` | the topologySpreadConstraints configs for the triggerer Pods | `[]`
 `triggerer.affinity` | the affinity configs for the triggerer Pods | `{}`
 `triggerer.tolerations` | the toleration configs for the triggerer Pods | `[]`
+`triggerer.topologySpreadConstraints` | the topologySpreadConstraints configs for the triggerer Pods | `[]`
 `triggerer.securityContext` | the security context for the triggerer Pods | `{}`
 `triggerer.labels` | labels for the triggerer Deployment | `{}`
 `triggerer.podLabels` | Pod labels for the triggerer Deployment | `{}`
@@ -355,9 +355,9 @@ Parameter | Description | Default
 `flower.enabled` | if the Flower UI should be deployed | `true`
 `flower.resources` | resource requests/limits for the flower Pods | `{}`
 `flower.nodeSelector` | the nodeSelector configs for the flower Pods | `{}`
-`flower.topologySpreadConstraints` | the topologySpreadConstraints configs for the flower Pods | `[]`
 `flower.affinity` | the affinity configs for the flower Pods | `{}`
 `flower.tolerations` | the toleration configs for the flower Pods | `[]`
+`flower.topologySpreadConstraints` | the topologySpreadConstraints configs for the flower Pods | `[]`
 `flower.securityContext` | the security context for the flower Pods | `{}`
 `flower.labels` | labels for the flower Deployment | `{}`
 `flower.podLabels` | Pod labels for the flower Deployment | `{}`
@@ -446,9 +446,9 @@ Parameter | Description | Default
 `pgbouncer.image.*` | configs for the pgbouncer container image | `<see values.yaml>`
 `pgbouncer.resources` | resource requests/limits for the pgbouncer Pods | `{}`
 `pgbouncer.nodeSelector` | the nodeSelector configs for the pgbouncer Pods | `{}`
-`pgbouncer.topologySpreadConstraints` | the topologySpreadConstraints configs for the pgbouncer Pods | `[]`
 `pgbouncer.affinity` | the affinity configs for the pgbouncer Pods | `{}`
 `pgbouncer.tolerations` | the toleration configs for the pgbouncer Pods | `[]`
+`pgbouncer.topologySpreadConstraints` | the topologySpreadConstraints configs for the pgbouncer Pods | `[]`
 `pgbouncer.securityContext` | the security context for the pgbouncer Pods | `{}`
 `pgbouncer.labels` | labels for the pgbouncer Deployment | `{}`
 `pgbouncer.podLabels` | Pod labels for the pgbouncer Deployment | `{}`

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -139,7 +139,7 @@ Please note, this chart is __independent__ from the official chart in the `apach
   - [`Mount Extra Persistent Volumes`](https://github.com/airflow-helm/charts/tree/main/charts/airflow/docs/faq/kubernetes/mount-persistent-volumes.md) <sup><sub>⭐</sub></sup>
   - [`Mount Files from Secrets/ConfigMaps`](https://github.com/airflow-helm/charts/tree/main/charts/airflow/docs/faq/kubernetes/mount-files.md) <a id="how-to-mount-secretsconfigmaps-as-files-on-workers"></a>
   - [`Mount Environment Variables from Secrets/ConfigMaps`](https://github.com/airflow-helm/charts/tree/main/charts/airflow/docs/faq/kubernetes/mount-environment-variables.md) <a id="how-to-create-airflow-variables"></a>
-  - [`Configure Pod Affinity/Selectors/Tolerations/TopologySpreadConstraints`](https://github.com/airflow-helm/charts/tree/main/charts/airflow/docs/faq/kubernetes/affinity-node-selectors-tolerations.md) <a id="how-to-use-pod-affinity-nodeselector-and-tolerations"></a>
+  - [`Configure Pod Affinity, Selectors, Tolerations, TopologySpreadConstraints`](https://github.com/airflow-helm/charts/tree/main/charts/airflow/docs/faq/kubernetes/affinity-node-selectors-tolerations.md) <a id="how-to-use-pod-affinity-nodeselector-and-tolerations"></a>
   - [`Include Extra Kubernetes Manifests`](https://github.com/airflow-helm/charts/tree/main/charts/airflow/docs/faq/kubernetes/extra-manifests.md) <a id="how-to-add-extra-manifests"></a>
 
 ## Examples

--- a/charts/airflow/docs/faq/kubernetes/affinity-node-selectors-tolerations.md
+++ b/charts/airflow/docs/faq/kubernetes/affinity-node-selectors-tolerations.md
@@ -2,16 +2,17 @@
 
 > Note, this page was written for the [`User-Community Airflow Helm Chart`](https://github.com/airflow-helm/charts/tree/main/charts/airflow)
 
-# Configure Pod Affinity/Selectors/Tolerations
+# Configure Pod Affinity/Selectors/Tolerations/TopologySpreadConstraints
 
 If your environment needs to use Pod [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity), 
-[nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector), [topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field),
-or [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/), 
+[nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector),
+[tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/),
+or [topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field),
 we provide many values that allow fine-grained control over the Pod definitions.
 
 ## Global Configs
 
-To set affinity, nodeSelector, topologySpreadConstraints, and tolerations for all airflow Pods, you may use the `airflow.{defaultNodeSelector,defaultTopologySpreadConstraints,defaultAffinity,defaultTolerations}` values:
+To set affinity, nodeSelector, tolerations, and topologySpreadConstraints for all airflow Pods, you may use the `airflow.{defaultNodeSelector,defaultAffinity,defaultTolerations,defaultTopologySpreadConstraints}` values:
 
 ```yaml
 airflow:
@@ -19,16 +20,6 @@ airflow:
   defaultNodeSelector: {}
     # my_node_label_1: value1
     # my_node_label_2: value2
-
-  ## https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
-  defaultTopologySpreadConstraints: []
-    # - maxSkew: 1
-    #   topologyKey: topology.kubernetes.io/zone
-    #   whenUnsatisfiable: DoNotSchedule
-    #   labelSelector:
-    #     matchLabels:
-    #       my_label_1: value1
-    #       my_label_2: value2
 
   ## https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
   defaultAffinity: {}
@@ -61,6 +52,16 @@ airflow:
     # - key: "key2"
     #   operator: "Exists"
     #   effect: "NoSchedule"
+  
+  ## https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  defaultTopologySpreadConstraints: []
+    # - maxSkew: 1
+    #   topologyKey: topology.kubernetes.io/zone
+    #   whenUnsatisfiable: DoNotSchedule
+    #   labelSelector:
+    #     matchLabels:
+    #       my_label_1: value1
+    #       my_label_2: value2
 
 ## if using the embedded postgres chart, you will also need to define these
 postgresql:
@@ -86,53 +87,53 @@ airflow:
   ## airflow KubernetesExecutor pod_template
   kubernetesPodTemplate:
     nodeSelector: {}
-    topologySpreadConstraints: []
     affinity: {}
     tolerations: []
+    topologySpreadConstraints: []
 
   ## sync deployments
   sync:
     nodeSelector: {}
-    topologySpreadConstraints: []
     affinity: {}
     tolerations: []
+    topologySpreadConstraints: []
 
 ## airflow schedulers
 scheduler:
   nodeSelector: {}
-  topologySpreadConstraints: []
   affinity: {}
   tolerations: []
+  topologySpreadConstraints: []
 
 ## airflow webserver
 web:
   nodeSelector: {}
-  topologySpreadConstraints: []
   affinity: {}
   tolerations: []
+  topologySpreadConstraints: []
 
 ## airflow workers
 workers:
   nodeSelector: {}
-  topologySpreadConstraints: []
   affinity: {}
   tolerations: []
+  topologySpreadConstraints: []
 
 ## airflow triggerer
 triggerer:
   nodeSelector: {}
-  topologySpreadConstraints: []
   affinity: {}
   tolerations: []
+  topologySpreadConstraints: []
 
 ## airflow workers
 flower:
   nodeSelector: {}
-  topologySpreadConstraints: []
   affinity: {}
   tolerations: []
+  topologySpreadConstraints: []
 ```
 
 > 🟦 __Tip__ 🟦
 >
-> The `airflow.{defaultNodeSelector,defaultTopologySpreadConstraints,defaultAffinity,defaultTolerations}` values are overridden by the per-resource values like `scheduler.{nodeSelector,topologySpreadConstraints,affinity,tolerations}`.
+> The `airflow.{defaultNodeSelector,defaultAffinity,defaultTolerations,defaultTopologySpreadConstraints}` values are overridden by the per-resource values like `scheduler.{nodeSelector,affinity,tolerations,topologySpreadConstraints}`.

--- a/charts/airflow/docs/faq/kubernetes/affinity-node-selectors-tolerations.md
+++ b/charts/airflow/docs/faq/kubernetes/affinity-node-selectors-tolerations.md
@@ -5,13 +5,13 @@
 # Configure Pod Affinity/Selectors/Tolerations
 
 If your environment needs to use Pod [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity), 
-[nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector), 
+[nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector), [topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field),
 or [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/), 
 we provide many values that allow fine-grained control over the Pod definitions.
 
 ## Global Configs
 
-To set affinity, nodeSelector, and tolerations for all airflow Pods, you may use the `airflow.{defaultNodeSelector,defaultAffinity,defaultTolerations}` values:
+To set affinity, nodeSelector, topologySpreadConstraints, and tolerations for all airflow Pods, you may use the `airflow.{defaultNodeSelector,defaultTopologySpreadConstraints,defaultAffinity,defaultTolerations}` values:
 
 ```yaml
 airflow:
@@ -19,6 +19,16 @@ airflow:
   defaultNodeSelector: {}
     # my_node_label_1: value1
     # my_node_label_2: value2
+
+  ## https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  defaultTopologySpreadConstraints: []
+    # - maxSkew: 1
+    #   topologyKey: topology.kubernetes.io/zone
+    #   whenUnsatisfiable: DoNotSchedule
+    #   labelSelector:
+    #     matchLabels:
+    #       my_label_1: value1
+    #       my_label_2: value2
 
   ## https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
   defaultAffinity: {}
@@ -69,53 +79,60 @@ redis:
 
 ## Per-Resource Configs
 
-To set affinity, nodeSelector, and tolerations for specific pods, you may use the following values:
+To set affinity, nodeSelector, topologySpreadConstraints, and tolerations for specific pods, you may use the following values:
 
 ```yaml
 airflow:
   ## airflow KubernetesExecutor pod_template
   kubernetesPodTemplate:
     nodeSelector: {}
+    topologySpreadConstraints: []
     affinity: {}
     tolerations: []
 
   ## sync deployments
   sync:
     nodeSelector: {}
+    topologySpreadConstraints: []
     affinity: {}
     tolerations: []
 
 ## airflow schedulers
 scheduler:
   nodeSelector: {}
+  topologySpreadConstraints: []
   affinity: {}
   tolerations: []
 
 ## airflow webserver
 web:
   nodeSelector: {}
+  topologySpreadConstraints: []
   affinity: {}
   tolerations: []
 
 ## airflow workers
 workers:
   nodeSelector: {}
+  topologySpreadConstraints: []
   affinity: {}
   tolerations: []
 
 ## airflow triggerer
 triggerer:
   nodeSelector: {}
+  topologySpreadConstraints: []
   affinity: {}
   tolerations: []
 
 ## airflow workers
 flower:
   nodeSelector: {}
+  topologySpreadConstraints: []
   affinity: {}
   tolerations: []
 ```
 
 > 🟦 __Tip__ 🟦
 >
-> The `airflow.{defaultNodeSelector,defaultAffinity,defaultTolerations}` values are overridden by the per-resource values like `scheduler.{nodeSelector,affinity,tolerations}`.
+> The `airflow.{defaultNodeSelector,defaultTopologySpreadConstraints,defaultAffinity,defaultTolerations}` values are overridden by the per-resource values like `scheduler.{nodeSelector,topologySpreadConstraints,affinity,tolerations}`.

--- a/charts/airflow/docs/faq/kubernetes/affinity-node-selectors-tolerations.md
+++ b/charts/airflow/docs/faq/kubernetes/affinity-node-selectors-tolerations.md
@@ -7,7 +7,7 @@
 If your environment needs to use Pod [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity), 
 [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector),
 [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/),
-or [topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field),
+or [topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/),
 we provide many values that allow fine-grained control over the Pod definitions.
 
 ## Global Configs
@@ -53,7 +53,7 @@ airflow:
     #   operator: "Exists"
     #   effect: "NoSchedule"
   
-  ## https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ## https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
   defaultTopologySpreadConstraints: []
     # - maxSkew: 1
     #   topologyKey: topology.kubernetes.io/zone

--- a/charts/airflow/docs/faq/kubernetes/affinity-node-selectors-tolerations.md
+++ b/charts/airflow/docs/faq/kubernetes/affinity-node-selectors-tolerations.md
@@ -2,7 +2,7 @@
 
 > Note, this page was written for the [`User-Community Airflow Helm Chart`](https://github.com/airflow-helm/charts/tree/main/charts/airflow)
 
-# Configure Pod Affinity/Selectors/Tolerations/TopologySpreadConstraints
+# Configure Pod Affinity, Selectors, Tolerations, TopologySpreadConstraints
 
 If your environment needs to use Pod [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity), 
 [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector),

--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -1,4 +1,5 @@
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.kubernetesPodTemplate.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.airflow.kubernetesPodTemplate.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.kubernetesPodTemplate.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.kubernetesPodTemplate.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.kubernetesPodTemplate.securityContext) }}
@@ -30,6 +31,10 @@ spec:
   {{- if $podNodeSelector }}
   nodeSelector:
     {{- $podNodeSelector | nindent 4 }}
+  {{- end }}
+  {{- if $podTopologySpreadConstraints }}
+  topologySpreadConstraints:
+    {{- $podTopologySpreadConstraints | nindent 4 }}
   {{- end }}
   {{- if $podAffinity }}
   affinity:

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -30,6 +30,14 @@ EXAMPLE USAGE: {{ include "airflow.nodeSelector" (dict "Release" .Release "Value
 {{- end }}
 
 {{/*
+Define the topologySpreadConstraints for airflow pods
+EXAMPLE USAGE: {{ include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" $topologySpreadConstraints) }}
+*/}}
+{{- define "airflow.podTopologySpreadConstraints" }}
+{{- .topologySpreadConstraints | default .Values.airflow.defaultTopologySpreadConstraints | toYaml }}
+{{- end }}
+
+{{/*
 Define the Affinity for airflow pods
 EXAMPLE USAGE: {{ include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" $affinity) }}
 */}}

--- a/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.airflow.dbMigrations.enabled) (not .Values.airflow.dbMigrations.runAsJob) }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.dbMigrations.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.airflow.dbMigrations.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.dbMigrations.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.dbMigrations.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.dbMigrations.securityContext) }}
@@ -64,6 +65,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/db-migrations/db-migrations-job.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-job.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.airflow.dbMigrations.enabled) (.Values.airflow.dbMigrations.runAsJob) }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.dbMigrations.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.airflow.dbMigrations.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.dbMigrations.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.dbMigrations.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.dbMigrations.securityContext) }}
@@ -58,6 +59,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.flower.enabled }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.flower.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.flower.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.flower.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.flower.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.flower.securityContext) }}
@@ -68,6 +69,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -52,6 +52,7 @@
 
 {{- if include "airflow.pgbouncer.should_use" . }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.pgbouncer.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.pgbouncer.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.pgbouncer.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.pgbouncer.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.pgbouncer.securityContext) }}
@@ -114,6 +115,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -1,4 +1,5 @@
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.scheduler.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.scheduler.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.scheduler.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.scheduler.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.scheduler.securityContext) }}
@@ -76,6 +77,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/sync/sync-connections-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-connections-deployment.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.airflow.connections) (.Values.airflow.connectionsUpdate) }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.airflow.sync.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
@@ -64,6 +65,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/sync/sync-connections-job.yaml
+++ b/charts/airflow/templates/sync/sync-connections-job.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.airflow.connections) (not .Values.airflow.connectionsUpdate) }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.scheduler.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.scheduler.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.scheduler.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.scheduler.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
@@ -58,6 +59,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/sync/sync-pools-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-pools-deployment.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.airflow.pools) (.Values.airflow.poolsUpdate) }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.airflow.sync.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
@@ -64,6 +65,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/sync/sync-pools-job.yaml
+++ b/charts/airflow/templates/sync/sync-pools-job.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.airflow.pools) (not .Values.airflow.poolsUpdate) }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.airflow.sync.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
@@ -58,6 +59,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/sync/sync-users-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-users-deployment.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.airflow.users) (.Values.airflow.usersUpdate) }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.airflow.sync.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
@@ -64,6 +65,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/sync/sync-users-job.yaml
+++ b/charts/airflow/templates/sync/sync-users-job.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.airflow.users) (not .Values.airflow.usersUpdate) }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.airflow.sync.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
@@ -58,6 +59,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/sync/sync-variables-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-variables-deployment.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.airflow.variables) (.Values.airflow.variablesUpdate) }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.airflow.sync.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
@@ -64,6 +65,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/sync/sync-variables-job.yaml
+++ b/charts/airflow/templates/sync/sync-variables-job.yaml
@@ -1,5 +1,6 @@
 {{- if and (.Values.airflow.variables) (not .Values.airflow.variablesUpdate) }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.airflow.sync.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
@@ -58,6 +59,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -1,5 +1,6 @@
 {{- if include "airflow.triggerer.should_use" . }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.triggerer.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.triggerer.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.triggerer.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.triggerer.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.triggerer.securityContext) }}
@@ -68,6 +69,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -1,4 +1,5 @@
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.web.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.web.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.web.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.web.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.web.securityContext) }}
@@ -70,6 +71,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.workers.enabled }}
 {{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.workers.nodeSelector) }}
+{{- $podTopologySpreadConstraints := include "airflow.podTopologySpreadConstraints" (dict "Release" .Release "Values" .Values "topologySpreadConstraints" .Values.workers.topologySpreadConstraints) }}
 {{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.workers.affinity) }}
 {{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.workers.tolerations) }}
 {{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.workers.securityContext) }}
@@ -74,6 +75,10 @@ spec:
       {{- if $podNodeSelector }}
       nodeSelector:
         {{- $podNodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if $podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- $podTopologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if $podAffinity }}
       affinity:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -186,11 +186,6 @@ airflow:
   ##
   defaultNodeSelector: {}
 
-  ## default topologySpreadConstraints for airflow Pods (is overridden by pod-specific values)
-  ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
-  defaultTopologySpreadConstraints: []
-
   ## default affinity configs for airflow Pods (is overridden by pod-specific values)
   ## - spec for Affinity:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -202,6 +197,12 @@ airflow:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
   ##
   defaultTolerations: []
+
+  ## default topologySpreadConstraints for airflow Pods (is overridden by pod-specific values)
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##
+  defaultTopologySpreadConstraints: []
 
   ## default securityContext configs for airflow Pods (is overridden by pod-specific values)
   ## - spec for PodSecurityContext:
@@ -317,12 +318,6 @@ airflow:
     ##
     nodeSelector: {}
 
-    ## the topologySpreadConstraints configs for the Pod template
-    ## - docs for topologySpreadConstraints:
-    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
-    ##
-    topologySpreadConstraints: []
-
     ## the affinity configs for the Pod template
     ## - spec for Affinity:
     ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -334,6 +329,12 @@ airflow:
     ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
     ##
     tolerations: []
+
+    ## the topologySpreadConstraints configs for the Pod template
+    ## - docs for topologySpreadConstraints:
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+    ##
+    topologySpreadConstraints: []
 
     ## labels for the Pod template
     ##
@@ -415,12 +416,6 @@ airflow:
     ##
     nodeSelector: {}
 
-    ## the topologySpreadConstraints configs for the db-migrations Pods
-    ## - docs for topologySpreadConstraints:
-    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
-    ##
-    topologySpreadConstraints: []
-
     ## the affinity configs for the db-migrations Pods
     ## - spec for Affinity:
     ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -432,6 +427,12 @@ airflow:
     ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
     ##
     tolerations: []
+
+    ## the topologySpreadConstraints configs for the db-migrations Pods
+    ## - docs for topologySpreadConstraints:
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+    ##
+    topologySpreadConstraints: []
 
     ## the security context for the db-migrations Pods
     ## - spec for PodSecurityContext:
@@ -482,12 +483,6 @@ airflow:
     ##
     nodeSelector: {}
 
-    ## the topologySpreadConstraints configs for the sync Pods
-    ## - docs for topologySpreadConstraints:
-    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
-    ##
-    topologySpreadConstraints: []
-
     ## the affinity configs for the sync Pods
     ## - spec for Affinity:
     ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -499,6 +494,12 @@ airflow:
     ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
     ##
     tolerations: []
+
+    ## the topologySpreadConstraints configs for the sync Pods
+    ## - docs for topologySpreadConstraints:
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+    ##
+    topologySpreadConstraints: []
 
     ## the security context for the sync Pods
     ## - spec for PodSecurityContext:
@@ -547,12 +548,6 @@ scheduler:
   ##
   nodeSelector: {}
 
-  ## the topologySpreadConstraints configs for the scheduler Pods
-  ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
-  ##
-  topologySpreadConstraints: []
-
   ## the affinity configs for the scheduler Pods
   ## - spec of Affinity:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -564,6 +559,12 @@ scheduler:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
   ##
   tolerations: []
+
+  ## the topologySpreadConstraints configs for the scheduler Pods
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##
+  topologySpreadConstraints: []
 
   ## the security context for the scheduler Pods
   ## - spec of PodSecurityContext:
@@ -752,12 +753,6 @@ web:
   ##
   nodeSelector: {}
 
-  ## the topologySpreadConstraints configs for the web Pods
-  ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
-  ##
-  topologySpreadConstraints: []
-
   ## the affinity configs for the web Pods
   ## - spec for Affinity:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -769,6 +764,12 @@ web:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
   ##
   tolerations: []
+
+  ## the topologySpreadConstraints configs for the web Pods
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##
+  topologySpreadConstraints: []
 
   ## the security context for the web Pods
   ## - spec for PodSecurityContext:
@@ -894,12 +895,6 @@ workers:
   ##
   nodeSelector: {}
 
-  ## the topologySpreadConstraints configs for the worker Pods
-  ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
-  ##
-  topologySpreadConstraints: []
-
   ## the affinity configs for the worker Pods
   ## - spec for Affinity:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -911,6 +906,12 @@ workers:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
   ##
   tolerations: []
+
+  ## the topologySpreadConstraints configs for the worker Pods
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##
+  topologySpreadConstraints: []
 
   ## the security context for the worker Pods
   ## - spec for PodSecurityContext:
@@ -1091,12 +1092,6 @@ triggerer:
   ##
   nodeSelector: {}
 
-  ## the topologySpreadConstraints configs for the triggerer Pods
-  ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
-  ##
-  topologySpreadConstraints: []
-
   ## the affinity configs for the triggerer Pods
   ## - spec for Affinity:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -1108,6 +1103,12 @@ triggerer:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
   ##
   tolerations: []
+
+  ## the topologySpreadConstraints configs for the triggerer Pods
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##
+  topologySpreadConstraints: []
 
   ## the security context for the triggerer Pods
   ## - spec for PodSecurityContext:
@@ -1214,12 +1215,6 @@ flower:
   ##
   nodeSelector: {}
 
-  ## the topologySpreadConstraints configs for the flower Pods
-  ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
-  ##
-  topologySpreadConstraints: []
-
   ## the affinity configs for the flower Pods
   ## - spec for Affinity:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -1231,6 +1226,12 @@ flower:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
   ##
   tolerations: []
+
+  ## the topologySpreadConstraints configs for the flower Pods
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##
+  topologySpreadConstraints: []
 
   ## the security context for the flower Pods
   ## - spec for PodSecurityContext:
@@ -1778,12 +1779,6 @@ pgbouncer:
   ##
   nodeSelector: {}
 
-  ## the topologySpreadConstraints configs for the pgbouncer Pods
-  ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
-  ##
-  topologySpreadConstraints: []
-
   ## the affinity configs for the pgbouncer Pods
   ## - spec for Affinity:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -1795,6 +1790,12 @@ pgbouncer:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core
   ##
   tolerations: []
+
+  ## the topologySpreadConstraints configs for the pgbouncer Pods
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##
+  topologySpreadConstraints: []
 
   ## the security context for the pgbouncer Pods
   ## - spec for PodSecurityContext:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -186,6 +186,11 @@ airflow:
   ##
   defaultNodeSelector: {}
 
+  ## default topologySpreadConstraints for airflow Pods (is overridden by pod-specific values)
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  defaultTopologySpreadConstraints: []
+
   ## default affinity configs for airflow Pods (is overridden by pod-specific values)
   ## - spec for Affinity:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -312,6 +317,12 @@ airflow:
     ##
     nodeSelector: {}
 
+    ## the topologySpreadConstraints configs for the Pod template
+    ## - docs for topologySpreadConstraints:
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+    ##
+    topologySpreadConstraints: []
+
     ## the affinity configs for the Pod template
     ## - spec for Affinity:
     ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -404,6 +415,12 @@ airflow:
     ##
     nodeSelector: {}
 
+    ## the topologySpreadConstraints configs for the db-migrations Pods
+    ## - docs for topologySpreadConstraints:
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+    ##
+    topologySpreadConstraints: []
+
     ## the affinity configs for the db-migrations Pods
     ## - spec for Affinity:
     ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -465,6 +482,12 @@ airflow:
     ##
     nodeSelector: {}
 
+    ## the topologySpreadConstraints configs for the sync Pods
+    ## - docs for topologySpreadConstraints:
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+    ##
+    topologySpreadConstraints: []
+
     ## the affinity configs for the sync Pods
     ## - spec for Affinity:
     ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -523,6 +546,12 @@ scheduler:
   ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   ##
   nodeSelector: {}
+
+  ## the topologySpreadConstraints configs for the scheduler Pods
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##
+  topologySpreadConstraints: []
 
   ## the affinity configs for the scheduler Pods
   ## - spec of Affinity:
@@ -723,6 +752,12 @@ web:
   ##
   nodeSelector: {}
 
+  ## the topologySpreadConstraints configs for the web Pods
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##
+  topologySpreadConstraints: []
+
   ## the affinity configs for the web Pods
   ## - spec for Affinity:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -858,6 +893,12 @@ workers:
   ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   ##
   nodeSelector: {}
+
+  ## the topologySpreadConstraints configs for the worker Pods
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##
+  topologySpreadConstraints: []
 
   ## the affinity configs for the worker Pods
   ## - spec for Affinity:
@@ -1050,6 +1091,12 @@ triggerer:
   ##
   nodeSelector: {}
 
+  ## the topologySpreadConstraints configs for the triggerer Pods
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##
+  topologySpreadConstraints: []
+
   ## the affinity configs for the triggerer Pods
   ## - spec for Affinity:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#affinity-v1-core
@@ -1166,6 +1213,12 @@ flower:
   ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   ##
   nodeSelector: {}
+
+  ## the topologySpreadConstraints configs for the flower Pods
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##
+  topologySpreadConstraints: []
 
   ## the affinity configs for the flower Pods
   ## - spec for Affinity:
@@ -1724,6 +1777,12 @@ pgbouncer:
   ##   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   ##
   nodeSelector: {}
+
+  ## the topologySpreadConstraints configs for the pgbouncer Pods
+  ## - docs for topologySpreadConstraints:
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##
+  topologySpreadConstraints: []
 
   ## the affinity configs for the pgbouncer Pods
   ## - spec for Affinity:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -200,7 +200,7 @@ airflow:
 
   ## default topologySpreadConstraints for airflow Pods (is overridden by pod-specific values)
   ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
   ##
   defaultTopologySpreadConstraints: []
 
@@ -332,7 +332,7 @@ airflow:
 
     ## the topologySpreadConstraints configs for the Pod template
     ## - docs for topologySpreadConstraints:
-    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
     ##
     topologySpreadConstraints: []
 
@@ -430,7 +430,7 @@ airflow:
 
     ## the topologySpreadConstraints configs for the db-migrations Pods
     ## - docs for topologySpreadConstraints:
-    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
     ##
     topologySpreadConstraints: []
 
@@ -497,7 +497,7 @@ airflow:
 
     ## the topologySpreadConstraints configs for the sync Pods
     ## - docs for topologySpreadConstraints:
-    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+    ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
     ##
     topologySpreadConstraints: []
 
@@ -562,7 +562,7 @@ scheduler:
 
   ## the topologySpreadConstraints configs for the scheduler Pods
   ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
   ##
   topologySpreadConstraints: []
 
@@ -767,7 +767,7 @@ web:
 
   ## the topologySpreadConstraints configs for the web Pods
   ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
   ##
   topologySpreadConstraints: []
 
@@ -909,7 +909,7 @@ workers:
 
   ## the topologySpreadConstraints configs for the worker Pods
   ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
   ##
   topologySpreadConstraints: []
 
@@ -1106,7 +1106,7 @@ triggerer:
 
   ## the topologySpreadConstraints configs for the triggerer Pods
   ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
   ##
   topologySpreadConstraints: []
 
@@ -1229,7 +1229,7 @@ flower:
 
   ## the topologySpreadConstraints configs for the flower Pods
   ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
   ##
   topologySpreadConstraints: []
 
@@ -1793,7 +1793,7 @@ pgbouncer:
 
   ## the topologySpreadConstraints configs for the pgbouncer Pods
   ## - docs for topologySpreadConstraints:
-  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
+  ##   https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
   ##
   topologySpreadConstraints: []
 


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- Resolves https://github.com/airflow-helm/charts/issues/581

## What does your PR do?

This PR adds the following values:

- `airflow.defaultTopologySpreadConstraints` (default: `[]`)
- `airflow.kubernetesPodTemplate.topologySpreadConstraints` (default: `[]`)
- `airflow.dbMigrations.topologySpreadConstraints` (default: `[]`)
- `airflow.sync.topologySpreadConstraints` (default: `[]`)
- `scheduler.topologySpreadConstraints` (default: `[]`)
- `web.topologySpreadConstraints` (default: `[]`)
- `workers.topologySpreadConstraints` (default: `[]`)
- `triggerer.topologySpreadConstraints` (default: `[]`)
- `flower.topologySpreadConstraints` (default: `[]`)
- `pgbouncer.topologySpreadConstraints` (default: `[]`)

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
