### PR TITLE
feat: add liveness probe for celery workers

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -308,6 +308,7 @@ Parameter | Description | Default
 `workers.celery.*` | configs for the celery worker Pods | `<see values.yaml>`
 `workers.terminationPeriod` | how many seconds to wait after SIGTERM before SIGKILL of the celery worker | `60`
 `workers.logCleanup.*` | configs for the log-cleanup sidecar of the worker Pods | `<see values.yaml>`
+`workers.livenessProbe.*` | configs for the worker Pods' liveness probe | `<see values.yaml>`
 `workers.extraPipPackages` | extra pip packages to install in the worker Pods | `[]`
 `workers.extraVolumeMounts` | extra VolumeMounts for the worker Pods | `[]`
 `workers.extraVolumes` | extra Volumes for the worker Pods | `[]`
@@ -333,7 +334,7 @@ Parameter | Description | Default
 `triggerer.safeToEvict` | if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true" | `true`
 `triggerer.podDisruptionBudget.*` | configs for the PodDisruptionBudget of the triggerer Deployment | `<see values.yaml>`
 `triggerer.capacity` | maximum number of triggers each triggerer will run at once (sets `AIRFLOW__TRIGGERER__DEFAULT_CAPACITY`) | `1000`
-`triggerer.livenessProbe.*` | liveness probe for the triggerer Pods | `<see values.yaml>`
+`triggerer.livenessProbe.*` | configs for the triggerer Pods' liveness probe | `<see values.yaml>`
 `triggerer.extraPipPackages` | extra pip packages to install in the triggerer Pods | `[]`
 `triggerer.extraVolumeMounts` | extra VolumeMounts for the triggerer Pods | `[]`
 `triggerer.extraVolumes` | extra Volumes for the triggerer Pods | `[]`

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -150,6 +150,22 @@ spec:
                         time.sleep(10)
                         active_tasks = i.active()[local_celery_host]
           {{- end }}
+          {{- if .Values.workers.celery.livenessProbe.enabled }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.workers.celery.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.workers.celery.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.workers.celery.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.workers.celery.livenessProbe.periodSeconds }}
+            exec:
+              command:
+                - "bash"
+                - "-c"
+                {{- if .Values.workers.celery.livenessProbe.command }}
+                {{ toYaml .Values.workers.celery.livenessProbe.command | nindent 16 }}
+                {{- else}}
+                - "exec celery --app airflow.executors.celery_executor.app inspect ping -d celery@${HOSTNAME}"
+                {{- end }}
+          {{- end }}
           ports:
             - name: wlog
               containerPort: 8793

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -150,21 +150,43 @@ spec:
                         time.sleep(10)
                         active_tasks = i.active()[local_celery_host]
           {{- end }}
-          {{- if .Values.workers.celery.livenessProbe.enabled }}
+          {{- if .Values.workers.livenessProbe.enabled }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.workers.celery.livenessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.workers.celery.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.workers.celery.livenessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.workers.celery.livenessProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.workers.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.workers.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.workers.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.workers.livenessProbe.periodSeconds }}
             exec:
               command:
-                - "bash"
+                {{- include "airflow.command" . | indent 16 }}
+                - "python"
+                - "-Wignore"
                 - "-c"
-                {{- if .Values.workers.celery.livenessProbe.command }}
-                {{ toYaml .Values.workers.celery.livenessProbe.command | nindent 16 }}
-                {{- else}}
-                - "exec celery --app airflow.executors.celery_executor.app inspect ping -d celery@${HOSTNAME}"
-                {{- end }}
+                - |
+                  import os
+                  import sys
+                  import subprocess
+                  from celery import Celery
+                  from celery.app.control import Inspect
+                  from typing import List
+
+                  def run_command(cmd: List[str]) -> str:
+                      process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+                      output, error = process.communicate()
+                      if error is not None:
+                          raise Exception(error)
+                      else:
+                          return output.decode(encoding="utf-8")
+
+                  broker_url = run_command(["bash", "-c", "eval $AIRFLOW__CELERY__BROKER_URL_CMD"])
+                  local_celery_host = f"celery@{os.environ['HOSTNAME']}"
+                  app = Celery(broker=broker_url)
+
+                  # ping the local celery worker to see if it's ok
+                  i = Inspect(app=app, destination=[local_celery_host], timeout=5.0)
+                  ping_responses = i.ping()
+                  if local_celery_host not in ping_responses:
+                      sys.exit(f"celery worker '{local_celery_host}' did not respond to ping")
           {{- end }}
           ports:
             - name: wlog

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -963,6 +963,14 @@ workers:
     ##
     gracefullTerminationPeriod: 600
 
+    ## config for celery worker liveness probes
+    livenessProbe:
+      enabled: false
+      initialDelaySeconds: 300
+      periodSeconds: 60
+      timeoutSeconds: 20
+      failureThreshold: 5
+
   ## how many seconds to wait after SIGTERM before SIGKILL of the celery worker
   ## - [WARNING] tasks that are still running during SIGKILL will be orphaned, this is important
   ##   to understand with KubernetesPodOperator(), as Pods may continue running

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -963,14 +963,6 @@ workers:
     ##
     gracefullTerminationPeriod: 600
 
-    ## config for celery worker liveness probes
-    livenessProbe:
-      enabled: false
-      initialDelaySeconds: 300
-      periodSeconds: 60
-      timeoutSeconds: 20
-      failureThreshold: 5
-
   ## how many seconds to wait after SIGTERM before SIGKILL of the celery worker
   ## - [WARNING] tasks that are still running during SIGKILL will be orphaned, this is important
   ##   to understand with KubernetesPodOperator(), as Pods may continue running
@@ -999,6 +991,15 @@ workers:
     ## the number of seconds between each check for files to delete
     ##
     intervalSeconds: 900
+
+  ## configs for the worker Pods' liveness probe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 60
+    failureThreshold: 5
 
   ## extra pip packages to install in the worker Pod
   ##


### PR DESCRIPTION
## What issues does your PR fix?

- fixes #600 

## What does your PR do?

Currently celery workers can enter a 'zombie' state where they become disconnected from celery and will no longer pick up new jobs. 

This PR adds a iveness probe (enabled by default) to detect such pods so they can be killed by k8s and recreated.

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)