### PR TITLE
feat: support `include_deferred` in pool sync for airflow 2.7.0

### DIFF
--- a/charts/airflow/docs/faq/dags/airflow-pools.md
+++ b/charts/airflow/docs/faq/dags/airflow-pools.md
@@ -14,9 +14,12 @@ airflow:
     - name: "pool_1"
       description: "example pool with 5 slots"
       slots: 5
+      
     - name: "pool_2"
       description: "example pool with 10 slots"
       slots: 10
+      ## if deferred tasks count towards the slot limit, requires airflow 2.7.0+ (default: false)
+      #include_deferred: false
 
   ## if we create a Deployment to perpetually sync `airflow.pools`
   poolsUpdate: true
@@ -29,8 +32,7 @@ airflow:
   pools:
     - name: "pool_1"
       description: "example pool with 2 cron policies"
-      include_deferred: false
-
+      
       ## the value of `slots` is ignored when `policies` is non-empty, but it must be set to an arbitrary value
       slots: 0
       

--- a/charts/airflow/docs/faq/dags/airflow-pools.md
+++ b/charts/airflow/docs/faq/dags/airflow-pools.md
@@ -29,7 +29,8 @@ airflow:
   pools:
     - name: "pool_1"
       description: "example pool with 2 cron policies"
-      
+      include_deferred: false
+
       ## the value of `slots` is ignored when `policies` is non-empty, but it must be set to an arbitrary value
       slots: 0
       

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -159,9 +159,11 @@ airflow:
   ##     - name: "pool_1"
   ##       description: "example pool with 5 slots"
   ##       slots: 5
+  ##       include_deferred: false
   ##     - name: "pool_2"
   ##       description: "example pool with 2 cron policies"
   ##       slots: 0
+  ##       include_deferred: false
   ##       ## at each sync interval, the policy with the most recently past `recurrence` is applied
   ##       policies:
   ##         - name: "scale up at 7pm UTC"

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -159,10 +159,10 @@ airflow:
   ##     - name: "pool_1"
   ##       description: "example pool with 5 slots"
   ##       slots: 5
-  ##       include_deferred: false
   ##     - name: "pool_2"
   ##       description: "example pool with 2 cron policies"
   ##       slots: 0
+  ##       ## if deferred tasks count towards the slot limit, requires airflow 2.7.0+ (default: false)
   ##       include_deferred: false
   ##       ## at each sync interval, the policy with the most recently past `recurrence` is applied
   ##       policies:


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

Airflow 2.7.0 added the `include_deferred` column to the `Pool` object (see https://github.com/apache/airflow/pull/32709), since this column is non-nullable, we must set it.

The same as upstream, our default state for `include_deferred` is `False`, if not specified.

## What does your PR do?

Add support for `include_deferred` to `sync_pools.tpl` so it will create and update pools successfully.

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [ ] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
