### PR TITLE
feat: add s3-sync sidecar option (breaking values changes)

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -385,7 +385,7 @@ Parameter | Description | Default
 --- | --- | ---
 `dags.path` | the airflow dags folder | `/opt/airflow/dags`
 `dags.persistence.*` | configs for the dags PVC | `<see values.yaml>`
-`dags.gitSync.*` | configs for the git-sync sidecar  | `<see values.yaml>`
+`dags.sync.*` | configs for the sync sidecars  | `<see values.yaml>`
 
 </details>
 

--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -43,13 +43,13 @@ spec:
   securityContext:
     {{- $podSecurityContext | nindent 4 }}
   {{- end }}
-  {{- if or ($extraPipPackages) (.Values.dags.gitSync.enabled) (.Values.airflow.kubernetesPodTemplate.extraInitContainers) }}
+  {{- if or ($extraPipPackages) (.Values.dags.sync.enabled) (.Values.airflow.kubernetesPodTemplate.extraInitContainers) }}
   initContainers:
     {{- if $extraPipPackages }}
     {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 4 }}
     {{- end }}
-    {{- if .Values.dags.gitSync.enabled }}
-    {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 4 }}
+    {{- if .Values.dags.sync.enabled }}
+    {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 4 }}
     {{- end }}
     {{- if .Values.airflow.kubernetesPodTemplate.extraInitContainers }}
     {{- toYaml .Values.airflow.kubernetesPodTemplate.extraInitContainers | nindent 4 }}

--- a/charts/airflow/templates/NOTES.txt
+++ b/charts/airflow/templates/NOTES.txt
@@ -104,7 +104,7 @@
 
 {{- /* if we show the git-sync known_hosts warning */ -}}
 {{- $known_host_warning := false }}
-{{- if and (.Values.dags.gitSync.enabled) (.Values.dags.gitSync.sshSecret) (not .Values.dags.gitSync.sshKnownHosts) }}
+{{- if and (.Values.dags.sync.enabled) (.Values.dags.sync.git.sshSecret) (not .Values.dags.sync.git.sshKnownHosts) }}
 {{- $known_host_warning = true }}
 {{- end }}
 
@@ -212,7 +212,7 @@ Use these commands to port-forward the Services to your localhost:
 
 {{- if $known_host_warning }}
 [HIGH] git-sync ssh known_hosts verification is disabled!
-  * HELP: set `dags.gitSync.sshKnownHosts` with the ssh fingerprint of your git host
+  * HELP: set `dags.sync.git.sshKnownHosts` with the ssh fingerprint of your git host
 {{ end }}
 
 {{- if $scheduler_livenessProbe_warning }}

--- a/charts/airflow/templates/_helpers/common.tpl
+++ b/charts/airflow/templates/_helpers/common.tpl
@@ -77,7 +77,7 @@ The path containing DAG files
 */}}
 {{- define "airflow.dags.path" -}}
 {{- if and (.Values.dags.sync.enabled) (eq .Values.dags.sync.type "git") -}}
-{{- printf "%s/repo/%s" (.Values.dags.path | trimSuffix "/") (.Values.dags.sync.repoSubPath | trimAll "/") -}}
+{{- printf "%s/repo/%s" (.Values.dags.path | trimSuffix "/") (.Values.dags.sync.git.repoSubPath | trimAll "/") -}}
 {{- else -}}
 {{- printf .Values.dags.path -}}
 {{- end -}}

--- a/charts/airflow/templates/_helpers/common.tpl
+++ b/charts/airflow/templates/_helpers/common.tpl
@@ -76,8 +76,8 @@ HTTP
 The path containing DAG files
 */}}
 {{- define "airflow.dags.path" -}}
-{{- if .Values.dags.gitSync.enabled -}}
-{{- printf "%s/repo/%s" (.Values.dags.path | trimSuffix "/") (.Values.dags.gitSync.repoSubPath | trimAll "/") -}}
+{{- if and (.Values.dags.sync.enabled) (eq .Values.dags.sync.type "git") -}}
+{{- printf "%s/repo/%s" (.Values.dags.path | trimSuffix "/") (.Values.dags.sync.repoSubPath | trimAll "/") -}}
 {{- else -}}
 {{- printf .Values.dags.path -}}
 {{- end -}}

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -190,7 +190,6 @@ EXAMPLE USAGE: {{ include "airflow.container.sync" (dict "Release" .Release "Val
 */}}
 {{- define "airflow.container.sync" }}
 - name: dags-{{ .Values.dags.sync.type }}-sync
-{{- end }}
 {{- with get .Values.dags.sync .Values.dags.sync.type }}
   image: {{ .image.repository }}:{{ .image.tag }}
 {{- end }}

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -118,6 +118,9 @@
 
 {{/* Checks for `dags.sync` */}}
 {{- if .Values.dags.sync.enabled }}
+  {{- if not (has .Values.dags.sync.type (list "git" "s3")) }}
+  {{ required "The `dags.sync.type` must be one of: [git, s3]!" nil }}
+  {{- end }}
   {{- if .Values.dags.persistence.enabled }}
   {{ required "If `dags.sync.enabled=true` and `dags.sync.type='git'`, then `persistence.enabled` must be disabled!" nil }}
   {{- end }}

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -116,19 +116,30 @@
   {{- end }}
 {{- end }}
 
-{{/* Checks for `dags.gitSync` */}}
-{{- if .Values.dags.gitSync.enabled }}
+{{/* Checks for `dags.sync` */}}
+{{- if .Values.dags.sync.enabled }}
   {{- if .Values.dags.persistence.enabled }}
-  {{ required "If `dags.gitSync.enabled=true`, then `persistence.enabled` must be disabled!" nil }}
+  {{ required "If `dags.sync.enabled=true` and `dags.sync.type='git'`, then `persistence.enabled` must be disabled!" nil }}
   {{- end }}
-  {{- if not .Values.dags.gitSync.repo }}
-  {{ required "If `dags.gitSync.enabled=true`, then `dags.gitSync.repo` must be non-empty!" nil }}
+  {{- if eq .Values.dags.sync.type "git" }}
+  {{- with .Values.dags.sync.git }}
+    {{- if not .repo }}
+    {{ required "If `dags.sync.enabled=true` and `dags.sync.type='git'`, then `dags.sync.git.repo` must be non-empty!" nil }}
+    {{- end }}
+    {{- if and (.sshSecret) (.httpSecret) }}
+    {{ required "At most, one of `dags.sync.git.sshSecret` and `dags.sync.git.httpSecret` can be defined!" nil }}
+    {{- end }}
+    {{- if and (.repo | lower | hasPrefix "git@github.com") (not .sshSecret) }}
+    {{ required "You must define `dags.sync.git.sshSecret` when using GitHub with SSH for `dags.sync.git.repo`!" nil }}
+    {{- end }}
   {{- end }}
-  {{- if and (.Values.dags.gitSync.sshSecret) (.Values.dags.gitSync.httpSecret) }}
-  {{ required "At most, one of `dags.gitSync.sshSecret` and `dags.gitSync.httpSecret` can be defined!" nil }}
   {{- end }}
-  {{- if and (.Values.dags.gitSync.repo | lower | hasPrefix "git@github.com") (not .Values.dags.gitSync.sshSecret) }}
-  {{ required "You must define `dags.gitSync.sshSecret` when using GitHub with SSH for `dags.gitSync.repo`!" nil }}
+  {{- if eq .Values.dags.sync.type "s3" }}
+  {{- with .Values.dags.sync.s3 }}
+    {{- if not .s3Path }}
+    {{ required "If `dags.sync.enabled=true` and `dags.sync.type='s3'`, then `dags.sync.s3.bucket` must be non-empty!" nil }}
+    {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}
 

--- a/charts/airflow/templates/config/secret-config-envs.yaml
+++ b/charts/airflow/templates/config/secret-config-envs.yaml
@@ -129,9 +129,9 @@ data:
   AIRFLOW__WEBSERVER__WEB_SERVER_PORT: {{ "8080" | b64enc | quote }}
   AIRFLOW__CELERY__FLOWER_PORT: {{ "5555" | b64enc | quote }}
 
-  {{- if and (.Values.dags.gitSync.enabled) (not .Values.airflow.config.AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL) }}
+  {{- if and (.Values.dags.sync.enabled) (not .Values.airflow.config.AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL) }}
   ## refresh the dags folder at the same frequency as git-sync
-  AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL: {{ .Values.dags.gitSync.syncWait | toString | b64enc | quote }}
+  AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL: {{ .Values.dags.sync.syncWait | toString | b64enc | quote }}
   {{- end }}
 
   {{- if and (.Values.airflow.legacyCommands) (not .Values.airflow.config.AIRFLOW__WEBSERVER__RBAC) }}

--- a/charts/airflow/templates/config/secret-known-hosts.yaml
+++ b/charts/airflow/templates/config/secret-known-hosts.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.dags.gitSync.enabled) (.Values.dags.gitSync.sshKnownHosts) }}
+{{- if and (.Values.dags.sync.enabled) (.Values.dags.sync.git.sshKnownHosts) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,5 +9,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  known_hosts: {{ .Values.dags.gitSync.sshKnownHosts | b64enc | quote }}
+  known_hosts: {{ .Values.dags.sync.git.sshKnownHosts | b64enc | quote }}
 {{- end }}

--- a/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
@@ -82,9 +82,9 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
@@ -107,9 +107,9 @@ spec:
             - name: scripts
               mountPath: /mnt/scripts
               readOnly: true
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.sync" . | indent 8 }}
         {{- end }}
       volumes:
         {{- $volumes | indent 8 }}

--- a/charts/airflow/templates/db-migrations/db-migrations-job.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-job.yaml
@@ -76,9 +76,9 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -86,9 +86,9 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -151,9 +151,9 @@ spec:
           volumeMounts:
             {{- $volumeMounts | indent 12 }}
           {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.sync" . | indent 8 }}
         {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -94,8 +94,8 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- if .Values.dags.sync.enabled }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -228,8 +228,8 @@ spec:
               readOnly: true
             {{- end }}
           {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- if .Values.dags.sync.enabled }}
+        {{- include "airflow.container.sync" . | indent 8 }}
         {{- end }}
         {{- if .Values.scheduler.logCleanup.enabled }}
         {{- $lc_resources := .Values.scheduler.logCleanup.resources }}

--- a/charts/airflow/templates/sync/sync-connections-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-connections-deployment.yaml
@@ -82,9 +82,9 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -113,9 +113,9 @@ spec:
               mountPath: "/mnt/templates"
               readOnly: true
             {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.sync" . | indent 8 }}
         {{- end }}
       volumes:
         {{- $volumes | indent 8 }}

--- a/charts/airflow/templates/sync/sync-connections-job.yaml
+++ b/charts/airflow/templates/sync/sync-connections-job.yaml
@@ -76,9 +76,9 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}

--- a/charts/airflow/templates/sync/sync-pools-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-pools-deployment.yaml
@@ -82,9 +82,9 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -108,9 +108,9 @@ spec:
             - name: scripts
               mountPath: /mnt/scripts
               readOnly: true
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.sync" . | indent 8 }}
         {{- end }}
       volumes:
         {{- $volumes | indent 8 }}

--- a/charts/airflow/templates/sync/sync-pools-job.yaml
+++ b/charts/airflow/templates/sync/sync-pools-job.yaml
@@ -76,9 +76,9 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}

--- a/charts/airflow/templates/sync/sync-users-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-users-deployment.yaml
@@ -82,9 +82,9 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -113,9 +113,9 @@ spec:
               mountPath: "/mnt/templates"
               readOnly: true
             {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.sync" . | indent 8 }}
         {{- end }}
       volumes:
         {{- $volumes | indent 8 }}

--- a/charts/airflow/templates/sync/sync-users-job.yaml
+++ b/charts/airflow/templates/sync/sync-users-job.yaml
@@ -76,9 +76,9 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}

--- a/charts/airflow/templates/sync/sync-variables-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-variables-deployment.yaml
@@ -82,9 +82,9 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -113,9 +113,9 @@ spec:
               mountPath: "/mnt/templates"
               readOnly: true
             {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- include "airflow.container.sync" . | indent 8 }}
         {{- end }}
       volumes:
         {{- $volumes | indent 8 }}

--- a/charts/airflow/templates/sync/sync-variables-job.yaml
+++ b/charts/airflow/templates/sync/sync-variables-job.yaml
@@ -76,9 +76,9 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
+        {{- if .Values.dags.sync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -86,8 +86,8 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- if .Values.dags.sync.enabled }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -160,8 +160,8 @@ spec:
           volumeMounts:
             {{- $volumeMounts | indent 12 }}
           {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- if .Values.dags.sync.enabled }}
+        {{- include "airflow.container.sync" . | indent 8 }}
         {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -88,8 +88,8 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- if .Values.dags.sync.enabled }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -144,8 +144,8 @@ spec:
               subPath: webserver_config.py
               readOnly: true
             {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- if .Values.dags.sync.enabled }}
+        {{- include "airflow.container.sync" . | indent 8 }}
         {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -91,8 +91,8 @@ spec:
         {{- if $extraPipPackages }}
         {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- if .Values.dags.sync.enabled }}
+        {{- include "airflow.container.sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
@@ -206,8 +206,8 @@ spec:
           volumeMounts:
             {{- $volumeMounts | indent 12 }}
           {{- end }}
-        {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" . | indent 8 }}
+        {{- if .Values.dags.sync.enabled }}
+        {{- include "airflow.container.sync" . | indent 8 }}
         {{- end }}
         {{- if .Values.workers.logCleanup.enabled }}
         {{- $lc_resources := .Values.workers.logCleanup.resources }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -283,7 +283,7 @@ airflow:
   ## FILE | pod_template.yaml
   ########################################
   ## - generates a file for `AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE`
-  ## - the `dags.gitSync` values will create a git-sync init-container in the pod
+  ## - the `dags.sync` values will create a sync init-container in the pod
   ## - the `airflow.extraPipPackages` will NOT be installed
   ##
   kubernetesPodTemplate:
@@ -919,7 +919,7 @@ workers:
     minAvailable: ""
 
   ## configs for the HorizontalPodAutoscaler of the worker Pods
-  ## - [WARNING] if using git-sync, ensure `dags.gitSync.resources` is set
+  ## - [WARNING] if using sync, ensure `dags.sync.resources` is set
   ## - [WARNING] if using worker log-cleanup, ensure `workers.logCleanup.resources` is set
   ##
   ## ____ EXAMPLE _______________
@@ -1360,18 +1360,21 @@ dags:
     ##
     size: 1Gi
 
-  ## configs for the git-sync sidecar (https://github.com/kubernetes/git-sync)
+  ## configs for the sync sidecar 
   ##
-  gitSync:
-    ## if the git-sync sidecar container is enabled
+  sync:
+    ## if the sync sidecar container is enabled
     ##
     enabled: false
 
-    ## the git-sync container image
+    ## type of sync
+    ## - git (https://github.com/kubernetes/git-sync)
+    ## - s3
     ##
+    type: null
+
+    ## sync container image
     image:
-      repository: registry.k8s.io/git-sync/git-sync
-      tag: v3.6.5
       pullPolicy: IfNotPresent
       uid: 65533
       gid: 65533
@@ -1382,85 +1385,128 @@ dags:
     ##
     resources: {}
 
-    ## the url of the git repo
-    ##
-    ## ____ EXAMPLE _______________
-    ##   # https git repo
-    ##   repo: "https://github.com/USERNAME/REPOSITORY.git"
-    ##
-    ## ____ EXAMPLE _______________
-    ##   # ssh git repo
-    ##   repo: "git@github.com:USERNAME/REPOSITORY.git"
-    ##
-    repo: ""
-
-    ## the sub-path within your repo where dags are located
-    ## - only dags under this path within your repo will be seen by airflow,
-    ##   (note, the full repo will still be cloned)
-    ##
-    repoSubPath: ""
-
-    ## the git branch to check out
-    ##
-    branch: master
-
-    ## the git revision (tag or hash) to check out
-    ##
-    revision: HEAD
-
-    ## shallow clone with a history truncated to the specified number of commits
-    ##
-    depth: 1
-
     ## the number of seconds between syncs
     ##
     syncWait: 60
-
-    ## the max number of seconds allowed for a complete sync
+    
+    ## git sync configs
     ##
-    syncTimeout: 120
+    git:
+      ## the git-sync container image
+      ##
+      image:
+        repository: registry.k8s.io/git-sync/git-sync
+        tag: v3.6.5
 
-    ## the git submodule behavior
-    ## - allowed values: "recursive", "shallow", "off"
-    ##
-    submodules: recursive
+      ## the url of the git repo
+      ##
+      ## ____ EXAMPLE _______________
+      ##   # https git repo
+      ##   repo: "https://github.com/USERNAME/REPOSITORY.git"
+      ##
+      ## ____ EXAMPLE _______________
+      ##   # ssh git repo
+      ##   repo: "git@github.com:USERNAME/REPOSITORY.git"
+      ##
+      repo: ""
 
-    ## the name of a pre-created Secret with git http credentials
-    ##
-    httpSecret: ""
+      ## the sub-path within your repo where dags are located
+      ## - only dags under this path within your repo will be seen by airflow,
+      ##   (note, the full repo will still be cloned)
+      ##
+      repoSubPath: ""
 
-    ## the key in `dags.gitSync.httpSecret` with your git username
-    ##
-    httpSecretUsernameKey: username
+      ## the git branch to check out
+      ##
+      branch: master
 
-    ## the key in `dags.gitSync.httpSecret` with your git password/token
-    ##
-    httpSecretPasswordKey: password
+      ## the git revision (tag or hash) to check out
+      ##
+      revision: HEAD
 
-    ## the name of a pre-created Secret with git ssh credentials
-    ##
-    sshSecret: ""
+      ## shallow clone with a history truncated to the specified number of commits
+      ##
+      depth: 1
+ 
+      ## the max number of seconds allowed for a complete sync
+      ##
+      syncTimeout: 120
 
-    ## the key in `dags.gitSync.sshSecret` with your ssh-key file
-    ##
-    sshSecretKey: id_rsa
+      ## the git submodule behavior
+      ## - allowed values: "recursive", "shallow", "off"
+      ##
+      submodules: recursive
 
-    ## the string value of a "known_hosts" file (for SSH only)
-    ## - [WARNING] known_hosts verification will be disabled if left empty, making you more
-    ##   vulnerable to repo spoofing attacks
-    ##
-    ## ____ EXAMPLE _______________
-    ##   sshKnownHosts: |-
-    ##     <HOST_NAME> ssh-rsa <HOST_KEY>
-    ##
-    sshKnownHosts: ""
+      ## the name of a pre-created Secret with git http credentials
+      ##
+      httpSecret: ""
 
-    ## the number of consecutive failures allowed before aborting
-    ##  - the first sync must succeed
-    ##  - a value of -1 will retry forever after the initial sync
-    ##
-    maxFailures: 0
+      ## the key in `dags.gitSync.httpSecret` with your git username
+      ##
+      httpSecretUsernameKey: username
 
+      ## the key in `dags.gitSync.httpSecret` with your git password/token
+      ##
+      httpSecretPasswordKey: password
+
+      ## the name of a pre-created Secret with git ssh credentials
+      ##
+      sshSecret: ""
+
+      ## the key in `dags.gitSync.sshSecret` with your ssh-key file
+      ##
+      sshSecretKey: id_rsa
+
+      ## the string value of a "known_hosts" file (for SSH only)
+      ## - [WARNING] known_hosts verification will be disabled if left empty, making you more
+      ##   vulnerable to repo spoofing attacks
+      ##
+      ## ____ EXAMPLE _______________
+      ##   sshKnownHosts: |-
+      ##     <HOST_NAME> ssh-rsa <HOST_KEY>
+      ##
+      sshKnownHosts: ""
+
+      ## the number of consecutive failures allowed before aborting
+      ##  - the first sync must succeed
+      ##  - a value of -1 will retry forever after the initial sync
+      ##
+      maxFailures: 0
+
+    ## configs for a sync from s3 object storage
+    ##
+    s3:
+      ## the s3-sync container image
+      ##
+      image:
+        repository: amazon/aws-cli
+        tag: 2.13.15
+      
+      ## the s3 path to the dags
+      ##
+      ## ____ EXAMPLE _______________
+      ##   # s3
+      ##   s3Path: "s3://<bucket>"
+      ##
+      ## ____ EXAMPLE _______________
+      ##   # s3 sub path
+      ##   s3Path: "s3://<bucket>/<path>/<to>/<dags>"
+      ##
+      s3Path: ""
+
+      ## the name of the pre-created Secret with AWS credentials
+      ##
+      secret: ""
+
+      ## the key in `dags.sync.git.secret` with your access key id
+      ##
+      idKey: keyId
+
+      ## the key in `dags.sync.git.secret` with your secret access key
+      secretKey: secretKey
+
+
+    
 ###################################
 ## CONFIG | Kubernetes Ingress
 ###################################

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1360,7 +1360,7 @@ dags:
     ##
     size: 1Gi
 
-  ## configs for the sync sidecar 
+  ## configs for the sync sidecar
   ##
   sync:
     ## if the sync sidecar container is enabled
@@ -1388,7 +1388,7 @@ dags:
     ## the number of seconds between syncs
     ##
     syncWait: 60
-    
+
     ## git sync configs
     ##
     git:
@@ -1481,7 +1481,7 @@ dags:
       image:
         repository: amazon/aws-cli
         tag: 2.13.15
-      
+
       ## the s3 path to the dags
       ##
       ## ____ EXAMPLE _______________
@@ -1506,7 +1506,6 @@ dags:
       secretKey: secretKey
 
 
-    
 ###################################
 ## CONFIG | Kubernetes Ingress
 ###################################

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1371,7 +1371,7 @@ dags:
     ## - git (https://github.com/kubernetes/git-sync)
     ## - s3
     ##
-    type: null
+    type: ""
 
     ## sync container image
     image:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1427,7 +1427,7 @@ dags:
       ## shallow clone with a history truncated to the specified number of commits
       ##
       depth: 1
- 
+
       ## the max number of seconds allowed for a complete sync
       ##
       syncTimeout: 120


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- fixes #249


## What does your PR do?

> Note: This PR suggests interface changes with `dags.gitSync` values. May need to be viewed in the context of #501.

- Generalises the definition of gitSync to a general sync pod definition
- Refactor `dags.gitSync` values to `dags.sync`
- Add support for s3 sync under new `dags.sync` values
- Amend value validation for `gitSync` and add new validation for `s3`
- Update README to reflect changes

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated