### PR TITLE
feat: add optional `rbac.secrets` value to give GET/LIST/WATCH on Secrets

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -407,7 +407,8 @@ Parameter | Description | Default
 Parameter | Description | Default
 --- | --- | ---
 `rbac.create` | if Kubernetes RBAC resources are created | `true`
-`rbac.events` | if the created RBAR role has GET/LIST access to Event resources | `false`
+`rbac.events` | if the created RBAC Role has GET/LIST on Event resources | `true`
+`rbac.secrets` | if the created RBAC Role has GET/LIST/WATCH on Secret resources | `false`
 
 </details>
 

--- a/charts/airflow/templates/rbac/airflow-role.yaml
+++ b/charts/airflow/templates/rbac/airflow-role.yaml
@@ -18,6 +18,16 @@ rules:
   - "get"
   - "list"
 {{- end }}
+{{- if .Values.rbac.secrets }}
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1610,6 +1610,11 @@ rbac:
   ##
   events: true
 
+  ## if the created RBAC Role has GET/LIST/WATCH on Secret resources
+  ## - this is a place holder to allow the implementors to over-write \
+  ## if they want their service account deployed in airflow namespace to access secrets, default value set to false
+  secrets: false
+
 ###################################
 ## CONFIG | Kubernetes ServiceAccount
 ###################################

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1602,6 +1602,8 @@ rbac:
   ## if Kubernetes RBAC resources are created
   ## - these allow the service account to create/delete Pods in the airflow namespace,
   ##   which is required for the KubernetesPodOperator() to function
+  ## - if `false`, you must create a custom Role and RoleBinding
+  ##   for the ServiceAccount defined in `serviceAccount.name`
   ##
   create: true
 
@@ -1611,8 +1613,7 @@ rbac:
   events: true
 
   ## if the created RBAC Role has GET/LIST/WATCH on Secret resources
-  ## - this is a place holder to allow the implementors to over-write \
-  ## if they want their service account deployed in airflow namespace to access secrets, default value set to false
+  ## - [WARNING] when true, workers/dags can read Secrets in airflow's namespace
   ##
   secrets: false
 

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1613,6 +1613,7 @@ rbac:
   ## if the created RBAC Role has GET/LIST/WATCH on Secret resources
   ## - this is a place holder to allow the implementors to over-write \
   ## if they want their service account deployed in airflow namespace to access secrets, default value set to false
+  ##
   secrets: false
 
 ###################################


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- N/A

## What does your PR do?

Currently, if a user wants to allow airflow Pods to read Secret resources, they must set `rbac.enabled` to false and provision their own Role/RoleBinding.

This PR adds the following values:

- `rbac.secrets` (default: `false`)
     - If `true`, the RBAC Role used by airflow Pods will be allowed to GET/LIST/WATCH on Secret resources

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)