### PR TITLE
feat: add `airflow.extraPodSpec` value

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -218,6 +218,7 @@ Parameter | Description | Default
 `airflow.defaultTolerations` | default toleration configs for airflow Pods (is overridden by pod-specific values) | `[]`
 `airflow.defaultSecurityContext` | default securityContext configs for Pods (is overridden by pod-specific values) | `{fsGroup: 0}`
 `airflow.podAnnotations` | extra annotations for airflow Pods | `{}`
+`airflow.extraPodSpec` | extra Spec for airflow Pods | `{}`
 `airflow.extraPipPackages` | extra pip packages to install in airflow Pods | `[]`
 `airflow.protectedPipPackages` | pip packages that are protected from upgrade/downgrade by `extraPipPackages` | `["apache-airflow"]`
 `airflow.extraEnv` | extra environment variables for the airflow Pods | `[]`

--- a/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
@@ -116,4 +116,7 @@ spec:
         - name: scripts
           secret:
             secretName: {{ include "airflow.fullname" . }}-db-migrations
+      {{- if .Values.airflow.extraPodSpec }}
+      {{- toYaml .Values.airflow.extraPodSpec | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -162,4 +162,7 @@ spec:
       volumes:
         {{- $volumes | indent 8 }}
       {{- end }}
+      {{- if .Values.airflow.extraPodSpec }}
+      {{- toYaml .Values.airflow.extraPodSpec | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -215,4 +215,7 @@ spec:
             sources:
               {{- include "airflow.pgbouncer.certs_volume_sources" . | indent 14 }}
         {{- end }}
+      {{- if .Values.airflow.extraPodSpec }}
+      {{- toYaml .Values.airflow.extraPodSpec | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -249,3 +249,6 @@ spec:
             name: {{ include "airflow.fullname" . }}-pod-template
         {{- end }}
       {{- end }}
+      {{- if .Values.airflow.extraPodSpec }}
+      {{- toYaml .Values.airflow.extraPodSpec | nindent 6 }}
+      {{- end }}

--- a/charts/airflow/templates/sync/sync-connections-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-connections-deployment.yaml
@@ -147,4 +147,7 @@ spec:
               {{- end }}
               {{- end }}
         {{- end }}
+      {{- if .Values.airflow.extraPodSpec }}
+      {{- toYaml .Values.airflow.extraPodSpec | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/airflow/templates/sync/sync-pools-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-pools-deployment.yaml
@@ -117,4 +117,7 @@ spec:
         - name: scripts
           secret:
             secretName: {{ include "airflow.fullname" . }}-sync-pools
+      {{- if .Values.airflow.extraPodSpec }}
+      {{- toYaml .Values.airflow.extraPodSpec | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/airflow/templates/sync/sync-users-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-users-deployment.yaml
@@ -147,4 +147,7 @@ spec:
               {{- end }}
               {{- end }}
         {{- end }}
+      {{- if .Values.airflow.extraPodSpec }}
+      {{- toYaml .Values.airflow.extraPodSpec | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/airflow/templates/sync/sync-variables-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-variables-deployment.yaml
@@ -147,4 +147,7 @@ spec:
               {{- end }}
               {{- end }}
         {{- end }}
+      {{- if .Values.airflow.extraPodSpec }}
+      {{- toYaml .Values.airflow.extraPodSpec | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -170,4 +170,7 @@ spec:
       volumes:
         {{- $volumes | indent 8 }}
       {{- end }}
+      {{- if .Values.airflow.extraPodSpec }}
+      {{- toYaml .Values.airflow.extraPodSpec | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -162,3 +162,6 @@ spec:
             {{- end }}
             defaultMode: 0644
         {{- end }}
+      {{- if .Values.airflow.extraPodSpec }}
+      {{- toYaml .Values.airflow.extraPodSpec | nindent 6 }}
+      {{- end }}

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -222,4 +222,7 @@ spec:
       volumes:
         {{- $volumes | indent 8 }}
       {{- end }}
+      {{- if .Values.airflow.extraPodSpec }}
+      {{- toYaml .Values.airflow.extraPodSpec | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -211,6 +211,10 @@ airflow:
   ##
   podAnnotations: {}
 
+  ## extra pod Spec for airflow Pods
+  ##
+  extraPodSpec: {}
+
   ## extra pip packages to install in airflow Pods
   ##
   ## ____ EXAMPLE _______________


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

Ability to add misc. spec resources on pods


## What does your PR do?

Add a extraPodSpec variable to allocate Spec of pods not anticipated by the chart.


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated