### PR TITLE
Make possible to configure multiple pgbouncer replicas. Signed-off-by: Ivan Shchukin <shchukin.ivan.v@gmail.com>

### DIFF
--- a/charts/airflow/CHANGELOG.md
+++ b/charts/airflow/CHANGELOG.md
@@ -8,6 +8,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 
 TBD
 
+## [8.9.0] - 2024-01-02
+
+### Changed
+- made possible to configure `pgbouncer` >1 replicas
+
 ## [8.8.0] - 2023-08-28
 
 > 🟨 __NOTES__ 🟨

--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Airflow Helm Chart (User Community) - the standard way to deploy Apache Airflow on Kubernetes with Helm
 name: airflow
-version: 8.8.0
+version: 8.9.0
 appVersion: 2.6.3
 icon: https://avatars.githubusercontent.com/u/71061241
 home: https://github.com/airflow-helm/charts/tree/main/charts/airflow

--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -73,7 +73,7 @@ metadata:
   {{- toYaml .Values.pgbouncer.annotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.pgbouncer.replicas | default "1" }}
   strategy:
     rollingUpdate:
       ## multiple pgbouncer pods can safely run concurrently

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1704,6 +1704,10 @@ pgbouncer:
   ##
   enabled: true
 
+  ## the number of pgbouncer Pods to run
+  ##
+  replicas: 1
+
   ## configs for the pgbouncer container image
   ##
   image:


### PR DESCRIPTION
## What issues does your PR fix?

No fixes

## What does your PR do?

made possible to configure `pgbouncer` >1 replicas

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [ ] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [X] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [X] CHANGELOG.md updated