### PR TITLE
feat: add `stats_users` configuration option for pgbouncer

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -457,6 +457,7 @@ Parameter | Description | Default
 `pgbouncer.poolSize` | sets pgbouncer config: `default_pool_size` | `20`
 `pgbouncer.logDisconnections` | sets pgbouncer config: `log_disconnections` | `0`
 `pgbouncer.logConnections` | sets pgbouncer config: `log_connections` | `0`
+`pgbouncer.statsUsers` | sets pgbouncer config: `stats_users` | null
 `pgbouncer.clientSSL.*` | ssl configs for: clients -> pgbouncer | `<see values.yaml>`
 `pgbouncer.serverSSL.*` | ssl configs for: pgbouncer -> postgres | `<see values.yaml>`
 

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -457,7 +457,7 @@ Parameter | Description | Default
 `pgbouncer.poolSize` | sets pgbouncer config: `default_pool_size` | `20`
 `pgbouncer.logDisconnections` | sets pgbouncer config: `log_disconnections` | `0`
 `pgbouncer.logConnections` | sets pgbouncer config: `log_connections` | `0`
-`pgbouncer.statsUsers` | sets pgbouncer config: `stats_users` | null
+`pgbouncer.statsUsers` | sets pgbouncer config: `stats_users` | `""`
 `pgbouncer.clientSSL.*` | ssl configs for: clients -> pgbouncer | `<see values.yaml>`
 `pgbouncer.serverSSL.*` | ssl configs for: pgbouncer -> postgres | `<see values.yaml>`
 

--- a/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
+++ b/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
@@ -24,6 +24,10 @@ auth_file = /home/pgbouncer/users.txt
 log_disconnections = {{ .Values.pgbouncer.logDisconnections }}
 log_connections = {{ .Values.pgbouncer.logConnections }}
 
+{{- if .Values.pgbouncer.statsUsers }}
+stats_users = {{ .Values.pgbouncer.statsUsers }}
+{{- end }}
+
 # locks will never be released when `pool_mode=transaction` (airflow initdb/upgradedb scripts create locks)
 server_reset_query = SELECT pg_advisory_unlock_all()
 server_reset_query_always = 1

--- a/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
+++ b/charts/airflow/templates/pgbouncer/_helpers/pgbouncer.tpl
@@ -25,6 +25,7 @@ log_disconnections = {{ .Values.pgbouncer.logDisconnections }}
 log_connections = {{ .Values.pgbouncer.logConnections }}
 
 {{- if .Values.pgbouncer.statsUsers }}
+{{ "" }}
 stats_users = {{ .Values.pgbouncer.statsUsers }}
 {{- end }}
 

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1826,6 +1826,10 @@ pgbouncer:
   ##
   logConnections: 0
 
+  ## sets pgbouncer config: `stats_users`
+  ##
+  statsUsers:
+
   ## ssl configs for: clients -> pgbouncer
   ##
   clientSSL:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1828,7 +1828,7 @@ pgbouncer:
 
   ## sets pgbouncer config: `stats_users`
   ##
-  statsUsers:
+  statsUsers: ""
 
   ## ssl configs for: clients -> pgbouncer
   ##


### PR DESCRIPTION
## What issues does your PR fix?

- fixes #819 


## What does your PR do?

This PR adds the following values:

- `pgbouncer.statsUsers` (default: `""`)
     - Sets the `stats_users` PgBouncer config in the `pgbouncer.ini` file.

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated