### PR TITLE
fix: add permission watch events to role

### DIFF
--- a/charts/airflow/templates/rbac/airflow-role.yaml
+++ b/charts/airflow/templates/rbac/airflow-role.yaml
@@ -17,6 +17,7 @@ rules:
   verbs:
   - "get"
   - "list"
+  - "watch"
 {{- end }}
 - apiGroups:
   - ""


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->



## What does your PR do?

This PR makes the following changes...

According to CNCF provider, till version 7.13.0, this still requires verb `watch` to enable functionalities following SparkCRD-generated pods log

https://github.com/apache/airflow/blob/9b5d6bfe273cf6af0972e28ff97f99ea325cd991/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py#L96

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated