### PR TITLE
feat: add chart name and overrides to airflow.fullname helper function

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -402,6 +402,24 @@ Parameter | Description | Default
 </details>
 
 <details>
+<summary><code>nameOverride</code></summary>
+
+Parameter | Description | Default
+--- | --- | ---
+`nameOverride` | replaces the name of the chart in the Construction of the base name for all resources in this chart | ``
+
+</details>
+
+<details>
+<summary><code>fullnameOverride</code></summary>
+
+Parameter | Description | Default
+--- | --- | ---
+`nameOverride` | fullnameOverride completely replaces the generated base name for all resources in this chart | ``
+
+</details>
+
+<details>
 <summary><code>rbac.*</code></summary>
 
 Parameter | Description | Default

--- a/charts/airflow/files/pod_template.kubernetes-helm-yaml
+++ b/charts/airflow/files/pod_template.kubernetes-helm-yaml
@@ -1,12 +1,12 @@
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.kubernetesPodTemplate.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.kubernetesPodTemplate.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.kubernetesPodTemplate.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.kubernetesPodTemplate.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.airflow.kubernetesPodTemplate.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.airflow.kubernetesPodTemplate.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.airflow.kubernetesPodTemplate.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.airflow.kubernetesPodTemplate.securityContext) }}
 {{- $extraPipPackages := .Values.airflow.kubernetesPodTemplate.extraPipPackages }}
 {{- $extraVolumeMounts := .Values.airflow.kubernetesPodTemplate.extraVolumeMounts }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
 {{- $extraVolumes := .Values.airflow.kubernetesPodTemplate.extraVolumes }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -46,10 +46,10 @@ spec:
   {{- if or ($extraPipPackages) (.Values.dags.gitSync.enabled) (.Values.airflow.kubernetesPodTemplate.extraInitContainers) }}
   initContainers:
     {{- if $extraPipPackages }}
-    {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 4 }}
+    {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 4 }}
     {{- end }}
     {{- if .Values.dags.gitSync.enabled }}
-    {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 4 }}
+    {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 4 }}
     {{- end }}
     {{- if .Values.airflow.kubernetesPodTemplate.extraInitContainers }}
     {{- toYaml .Values.airflow.kubernetesPodTemplate.extraInitContainers | nindent 4 }}
@@ -66,7 +66,7 @@ spec:
           value: LocalExecutor
         {{- /* NOTE: the FIRST definition of an `env` takes precedence (so we include user-defined `env` LAST) */ -}}
         {{- /* NOTE: we set `CONNECTION_CHECK_MAX_COUNT=20` to enable airflow's `/entrypoint` db connection check */ -}}
-        {{- include "airflow.env" (dict "Release" .Release "Values" .Values "CONNECTION_CHECK_MAX_COUNT" "20")  | indent 8 }}
+        {{- include "airflow.env" (dict "Release" .Release "Chart" .Chart "Values" .Values "CONNECTION_CHECK_MAX_COUNT" "20")  | indent 8 }}
       ports: []
       command: []
       args: []

--- a/charts/airflow/templates/_helpers/common.tpl
+++ b/charts/airflow/templates/_helpers/common.tpl
@@ -1,10 +1,20 @@
 {{/*
 Construct the base name for all resources in this chart.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "airflow.fullname" -}}
-{{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 The version of airflow being deployed.

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -23,7 +23,7 @@ Define the command/entrypoint configs for airflow containers
 
 {{/*
 Define the nodeSelector for airflow pods
-EXAMPLE USAGE: {{ include "airflow.nodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" $nodeSelector) }}
+EXAMPLE USAGE: {{ include "airflow.nodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" $nodeSelector) }}
 */}}
 {{- define "airflow.podNodeSelector" }}
 {{- .nodeSelector | default .Values.airflow.defaultNodeSelector | toYaml }}
@@ -31,7 +31,7 @@ EXAMPLE USAGE: {{ include "airflow.nodeSelector" (dict "Release" .Release "Value
 
 {{/*
 Define the Affinity for airflow pods
-EXAMPLE USAGE: {{ include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" $affinity) }}
+EXAMPLE USAGE: {{ include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" $affinity) }}
 */}}
 {{- define "airflow.podAffinity" }}
 {{- .affinity | default .Values.airflow.defaultAffinity | toYaml }}
@@ -39,7 +39,7 @@ EXAMPLE USAGE: {{ include "airflow.podAffinity" (dict "Release" .Release "Values
 
 {{/*
 Define the Tolerations for airflow pods
-EXAMPLE USAGE: {{ include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" $tolerations) }}
+EXAMPLE USAGE: {{ include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" $tolerations) }}
 */}}
 {{- define "airflow.podTolerations" }}
 {{- .tolerations | default .Values.airflow.defaultTolerations | toYaml }}
@@ -47,7 +47,7 @@ EXAMPLE USAGE: {{ include "airflow.podTolerations" (dict "Release" .Release "Val
 
 {{/*
 Define the PodSecurityContext for airflow pods
-EXAMPLE USAGE: {{ include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" $securityContext) }}
+EXAMPLE USAGE: {{ include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" $securityContext) }}
 */}}
 {{- define "airflow.podSecurityContext" }}
 {{- .securityContext | default .Values.airflow.defaultSecurityContext | toYaml }}
@@ -55,7 +55,7 @@ EXAMPLE USAGE: {{ include "airflow.podSecurityContext" (dict "Release" .Release 
 
 {{/*
 Define an init-container which checks the DB status
-EXAMPLE USAGE: {{ include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) }}
+EXAMPLE USAGE: {{ include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) }}
 */}}
 {{- define "airflow.init_container.check_db" }}
 - name: check-db
@@ -82,7 +82,7 @@ EXAMPLE USAGE: {{ include "airflow.init_container.check_db" (dict "Release" .Rel
 
 {{/*
 Define an init-container which waits for DB migrations
-EXAMPLE USAGE: {{ include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) }}
+EXAMPLE USAGE: {{ include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) }}
 */}}
 {{- define "airflow.init_container.wait_for_db_migrations" }}
 - name: wait-for-db-migrations
@@ -159,7 +159,7 @@ EXAMPLE USAGE: {{ include "airflow.init_container.wait_for_db_migrations" (dict 
 
 {{/*
 Define an init-container which installs a list of pip packages
-EXAMPLE USAGE: {{ include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
+EXAMPLE USAGE: {{ include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
 */}}
 {{- define "airflow.init_container.install_pip_packages" }}
 - name: install-pip-packages
@@ -186,7 +186,7 @@ EXAMPLE USAGE: {{ include "airflow.init_container.install_pip_packages" (dict "R
 
 {{/*
 Define a container which regularly syncs a git-repo
-EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") }}
+EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") }}
 */}}
 {{- define "airflow.container.git_sync" }}
 {{- if .sync_one_time }}
@@ -278,7 +278,7 @@ EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release 
 
 {{/*
 Define a container which regularly deletes airflow logs older than a retention period.
-EXAMPLE USAGE: {{ include "airflow.container.log_cleanup" (dict "Release" .Release "Values" .Values "resources" $lc_resources "retention_min" $lc_retention_min "interval_sec" $lc_interval_sec) }}
+EXAMPLE USAGE: {{ include "airflow.container.log_cleanup" (dict "Release" .Release "Chart" .Chart "Values" .Values "resources" $lc_resources "retention_min" $lc_retention_min "interval_sec" $lc_interval_sec) }}
 */}}
 {{- define "airflow.container.log_cleanup" }}
 - name: log-cleanup
@@ -341,7 +341,7 @@ EXAMPLE USAGE: {{ include "airflow.container.log_cleanup" (dict "Release" .Relea
 
 {{/*
 The list of `volumeMounts` for web/scheduler/worker/flower container
-EXAMPLE USAGE: {{ include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
+EXAMPLE USAGE: {{ include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
 */}}
 {{- define "airflow.volumeMounts" }}
 {{- /* airflow_local_settings.py */ -}}
@@ -399,7 +399,7 @@ EXAMPLE USAGE: {{ include "airflow.volumeMounts" (dict "Release" .Release "Value
 
 {{/*
 The list of `volumes` for web/scheduler/worker/flower Pods
-EXAMPLE USAGE: {{ include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
+EXAMPLE USAGE: {{ include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 */}}
 {{- define "airflow.volumes" }}
 {{- /* airflow_local_settings.py */ -}}
@@ -489,7 +489,7 @@ The list of `envFrom` for web/scheduler/worker/flower Pods
 
 {{/*
 The list of `env` for web/scheduler/worker/flower Pods
-EXAMPLE USAGE: {{ include "airflow.env" (dict "Release" .Release "Values" .Values "CONNECTION_CHECK_MAX_COUNT" "0") }}
+EXAMPLE USAGE: {{ include "airflow.env" (dict "Release" .Release "Chart" .Chart "Values" .Values "CONNECTION_CHECK_MAX_COUNT" "0") }}
 */}}
 {{- define "airflow.env" }}
 {{- /* set DATABASE_USER */ -}}

--- a/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-deployment.yaml
@@ -1,11 +1,11 @@
 {{- if and (.Values.airflow.dbMigrations.enabled) (not .Values.airflow.dbMigrations.runAsJob) }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.dbMigrations.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.dbMigrations.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.dbMigrations.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.dbMigrations.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.airflow.dbMigrations.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.airflow.dbMigrations.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.airflow.dbMigrations.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.airflow.dbMigrations.securityContext) }}
 {{- $extraPipPackages := .Values.airflow.extraPipPackages }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -80,13 +80,13 @@ spec:
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: db-migrations
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/db-migrations/db-migrations-job.yaml
+++ b/charts/airflow/templates/db-migrations/db-migrations-job.yaml
@@ -1,11 +1,11 @@
 {{- if and (.Values.airflow.dbMigrations.enabled) (.Values.airflow.dbMigrations.runAsJob) }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.dbMigrations.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.dbMigrations.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.dbMigrations.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.dbMigrations.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.airflow.dbMigrations.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.airflow.dbMigrations.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.airflow.dbMigrations.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.airflow.dbMigrations.securityContext) }}
 {{- $extraPipPackages := .Values.airflow.extraPipPackages }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -74,13 +74,13 @@ spec:
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: db-migrations
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -1,13 +1,13 @@
 {{- if .Values.flower.enabled }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.flower.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.flower.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.flower.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.flower.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.flower.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.flower.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.flower.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.flower.securityContext) }}
 {{- $extraPipPackages := concat .Values.airflow.extraPipPackages .Values.flower.extraPipPackages }}
 {{- $extraVolumeMounts := .Values.flower.extraVolumeMounts }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
 {{- $extraVolumes := .Values.flower.extraVolumes }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -84,14 +84,14 @@ spec:
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: airflow-flower
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -51,10 +51,10 @@
 {{- end }}
 
 {{- if include "airflow.pgbouncer.should_use" . }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.pgbouncer.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.pgbouncer.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.pgbouncer.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.pgbouncer.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.pgbouncer.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.pgbouncer.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.pgbouncer.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.pgbouncer.securityContext) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -1,12 +1,12 @@
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.scheduler.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.scheduler.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.scheduler.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.scheduler.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.scheduler.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.scheduler.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.scheduler.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.scheduler.securityContext) }}
 {{- $extraPipPackages := concat .Values.airflow.extraPipPackages .Values.scheduler.extraPipPackages }}
 {{- $extraVolumeMounts := .Values.scheduler.extraVolumeMounts }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
 {{- $extraVolumes := .Values.scheduler.extraVolumes }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -92,13 +92,13 @@ spec:
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- if .Values.scheduler.extraInitContainers }}
         {{- toYaml .Values.scheduler.extraInitContainers | nindent 8 }}
         {{- end }}
@@ -235,7 +235,7 @@ spec:
         {{- $lc_resources := .Values.scheduler.logCleanup.resources }}
         {{- $lc_retention_min := .Values.scheduler.logCleanup.retentionMinutes }}
         {{- $lc_interval_sec := .Values.scheduler.logCleanup.intervalSeconds }}
-        {{- include "airflow.container.log_cleanup" (dict "Release" .Release "Values" .Values "resources" $lc_resources "retention_min" $lc_retention_min "interval_sec" $lc_interval_sec) | indent 8 }}
+        {{- include "airflow.container.log_cleanup" (dict "Release" .Release "Chart" .Chart "Values" .Values "resources" $lc_resources "retention_min" $lc_retention_min "interval_sec" $lc_interval_sec) | indent 8 }}
         {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}

--- a/charts/airflow/templates/sync/sync-connections-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-connections-deployment.yaml
@@ -1,11 +1,11 @@
 {{- if and (.Values.airflow.connections) (.Values.airflow.connectionsUpdate) }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
 {{- $extraPipPackages := .Values.airflow.extraPipPackages }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -80,14 +80,14 @@ spec:
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-connections
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-connections-job.yaml
+++ b/charts/airflow/templates/sync/sync-connections-job.yaml
@@ -1,11 +1,11 @@
 {{- if and (.Values.airflow.connections) (not .Values.airflow.connectionsUpdate) }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.scheduler.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.scheduler.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.scheduler.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.scheduler.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.scheduler.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.scheduler.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
 {{- $extraPipPackages := .Values.airflow.extraPipPackages }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -74,14 +74,14 @@ spec:
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-connections
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-pools-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-pools-deployment.yaml
@@ -1,11 +1,11 @@
 {{- if and (.Values.airflow.pools) (.Values.airflow.poolsUpdate) }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
 {{- $extraPipPackages := .Values.airflow.extraPipPackages }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -80,14 +80,14 @@ spec:
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-pools
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-pools-job.yaml
+++ b/charts/airflow/templates/sync/sync-pools-job.yaml
@@ -1,11 +1,11 @@
 {{- if and (.Values.airflow.pools) (not .Values.airflow.poolsUpdate) }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
 {{- $extraPipPackages := .Values.airflow.extraPipPackages }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -74,14 +74,14 @@ spec:
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-pools
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-users-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-users-deployment.yaml
@@ -1,11 +1,11 @@
 {{- if and (.Values.airflow.users) (.Values.airflow.usersUpdate) }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
 {{- $extraPipPackages := .Values.airflow.extraPipPackages }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -80,14 +80,14 @@ spec:
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-users
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-users-job.yaml
+++ b/charts/airflow/templates/sync/sync-users-job.yaml
@@ -1,11 +1,11 @@
 {{- if and (.Values.airflow.users) (not .Values.airflow.usersUpdate) }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
 {{- $extraPipPackages := .Values.airflow.extraPipPackages }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -74,14 +74,14 @@ spec:
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-users
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-variables-deployment.yaml
+++ b/charts/airflow/templates/sync/sync-variables-deployment.yaml
@@ -1,11 +1,11 @@
 {{- if and (.Values.airflow.variables) (.Values.airflow.variablesUpdate) }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
 {{- $extraPipPackages := .Values.airflow.extraPipPackages }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -80,14 +80,14 @@ spec:
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-variables
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/sync/sync-variables-job.yaml
+++ b/charts/airflow/templates/sync/sync-variables-job.yaml
@@ -1,11 +1,11 @@
 {{- if and (.Values.airflow.variables) (not .Values.airflow.variablesUpdate) }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.airflow.sync.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.airflow.sync.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.airflow.sync.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.airflow.sync.securityContext) }}
 {{- $extraPipPackages := .Values.airflow.extraPipPackages }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -74,14 +74,14 @@ spec:
       serviceAccountName: {{ include "airflow.serviceAccountName" . }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
         ## git-sync is included so "airflow plugins" & "python packages" can be stored in the dags repo
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: sync-airflow-variables
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -1,13 +1,13 @@
 {{- if include "airflow.triggerer.should_use" . }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.triggerer.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.triggerer.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.triggerer.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.triggerer.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.triggerer.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.triggerer.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.triggerer.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.triggerer.securityContext) }}
 {{- $extraPipPackages := concat .Values.airflow.extraPipPackages .Values.triggerer.extraPipPackages }}
 {{- $extraVolumeMounts := .Values.triggerer.extraVolumeMounts }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
 {{- $extraVolumes := .Values.triggerer.extraVolumes }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -84,13 +84,13 @@ spec:
       {{- end }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: airflow-triggerer
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -1,12 +1,12 @@
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.web.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.web.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.web.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.web.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.web.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.web.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.web.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.web.securityContext) }}
 {{- $extraPipPackages := concat .Values.airflow.extraPipPackages .Values.web.extraPipPackages }}
 {{- $extraVolumeMounts := .Values.web.extraVolumeMounts }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
 {{- $extraVolumes := .Values.web.extraVolumes }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -86,13 +86,13 @@ spec:
       {{- end }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: airflow-web
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -1,13 +1,13 @@
 {{- if .Values.workers.enabled }}
-{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Values" .Values "nodeSelector" .Values.workers.nodeSelector) }}
-{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Values" .Values "affinity" .Values.workers.affinity) }}
-{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Values" .Values "tolerations" .Values.workers.tolerations) }}
-{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Values" .Values "securityContext" .Values.workers.securityContext) }}
+{{- $podNodeSelector := include "airflow.podNodeSelector" (dict "Release" .Release "Chart" .Chart "Values" .Values "nodeSelector" .Values.workers.nodeSelector) }}
+{{- $podAffinity := include "airflow.podAffinity" (dict "Release" .Release "Chart" .Chart "Values" .Values "affinity" .Values.workers.affinity) }}
+{{- $podTolerations := include "airflow.podTolerations" (dict "Release" .Release "Chart" .Chart "Values" .Values "tolerations" .Values.workers.tolerations) }}
+{{- $podSecurityContext := include "airflow.podSecurityContext" (dict "Release" .Release "Chart" .Chart "Values" .Values "securityContext" .Values.workers.securityContext) }}
 {{- $extraPipPackages := concat .Values.airflow.extraPipPackages .Values.workers.extraPipPackages }}
 {{- $extraVolumeMounts := .Values.workers.extraVolumeMounts }}
-{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $volumeMounts := include "airflow.volumeMounts" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumeMounts" $extraVolumeMounts) }}
 {{- $extraVolumes := .Values.workers.extraVolumes }}
-{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
+{{- $volumes := include "airflow.volumes" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages "extraVolumes" $extraVolumes "extraVolumeMounts" $extraVolumeMounts) }}
 apiVersion: apps/v1
 ## StatefulSet gives workers consistent DNS names, allowing webserver access to log files
 kind: StatefulSet
@@ -89,13 +89,13 @@ spec:
       {{- end }}
       initContainers:
         {{- if $extraPipPackages }}
-        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
+        {{- include "airflow.init_container.install_pip_packages" (dict "Release" .Release "Chart" .Chart "Values" .Values "extraPipPackages" $extraPipPackages) | indent 8 }}
         {{- end }}
         {{- if .Values.dags.gitSync.enabled }}
-        {{- include "airflow.container.git_sync" (dict "Release" .Release "Values" .Values "sync_one_time" "true") | indent 8 }}
+        {{- include "airflow.container.git_sync" (dict "Release" .Release "Chart" .Chart "Values" .Values "sync_one_time" "true") | indent 8 }}
         {{- end }}
-        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
-        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.check_db" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Chart" .Chart "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
       containers:
         - name: airflow-worker
           {{- include "airflow.image" . | indent 10 }}
@@ -213,7 +213,7 @@ spec:
         {{- $lc_resources := .Values.workers.logCleanup.resources }}
         {{- $lc_retention_min := .Values.workers.logCleanup.retentionMinutes }}
         {{- $lc_interval_sec := .Values.workers.logCleanup.intervalSeconds }}
-        {{- include "airflow.container.log_cleanup" (dict "Release" .Release "Values" .Values "resources" $lc_resources "retention_min" $lc_retention_min "interval_sec" $lc_interval_sec) | indent 8 }}
+        {{- include "airflow.container.log_cleanup" (dict "Release" .Release "Chart" .Chart "Values" .Values "resources" $lc_resources "retention_min" $lc_retention_min "interval_sec" $lc_interval_sec) | indent 8 }}
         {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1596,6 +1596,14 @@ ingress:
     succeedingPaths: []
 
 ###################################
+## CONFIG | Kubernetes Resources
+###################################
+## nameOverride replaces the name of the chart in the Construction of the base name for all resources in this chart
+nameOverride: ""
+## fullnameOverride completely replaces the generated base name for all resources in this chart
+fullnameOverride: ""
+
+###################################
 ## CONFIG | Kubernetes RBAC
 ###################################
 rbac:


### PR DESCRIPTION
## What does your PR do?

This PR makes the following changes...

Added the Chart name as a suffix to the _airflow.fullname_ function, this is very useful for recognizing the resources deployed by airflow chart when is a sub chart.

Added _nameOverride_ and _fullnameOverride_ to allow the user to customize resource suffixes.

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated