### PR TITLE
Patch for IPv6 native clusters (airflow binds to ipv4 only by default)

### DIFF
--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -111,7 +111,11 @@ spec:
           args:
             - "bash"
             - "-c"
+            {{- if .Values.web.ipv6.enabled }}
+            - "exec airflow webserver --hostname [::]"
+            {{- else }}
             - "exec airflow webserver"
+            {{- end }}
           {{- if .Values.web.livenessProbe.enabled }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -795,6 +795,11 @@ web:
     nodePort:
       http: ""
 
+  ## configs to determine if this runs on an ipv6 native cluster
+  ##
+  ipv6:
+    enabled: false
+
   ## configs for the web Pods' readiness probe
   ##
   readinessProbe:


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?
-fixes IPv6 native clusters cannot be reached on IPv4 addresses.

## What does your PR do?

This PR makes the following changes...
Adds --hostname [::] to the exec airflow webserver command so that it binds to ipv6 as well as ipv4.

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated