### PR TITLE
Fix user sync for Airflow 2.9.0

### DIFF
--- a/charts/airflow/templates/sync/_helpers/sync_users.tpl
+++ b/charts/airflow/templates/sync/_helpers/sync_users.tpl
@@ -27,15 +27,19 @@ flask_appbuilder = flask_app.appbuilder
 
 # airflow moves the User and Role models around in different versions
 try:
-  # since 2.7.0
-  from airflow.auth.managers.fab.models import User, Role
+  # since 2.9.0
+  from airflow.providers.fab.auth_manager.models import User, Role
 except ModuleNotFoundError:
   try:
-    # from 2.3.0 to 2.6.3
-    from airflow.www.fab_security.sqla.models import User, Role
+    # from 2.7.0 to 2.8.4
+    from airflow.auth.managers.fab.models import User, Role
   except ModuleNotFoundError:
-    # before 2.3.0
-    from flask_appbuilder.security.sqla.models import User, Role
+    try:
+      # from 2.3.0 to 2.6.3
+      from airflow.www.fab_security.sqla.models import User, Role
+    except ModuleNotFoundError:
+      # before 2.3.0
+      from flask_appbuilder.security.sqla.models import User, Role
 
 
 #############


### PR DESCRIPTION
Fix sync_users.tpl for Airflow 2.9.0

<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- fixes #847 


## What does your PR do?

Fix the sync user templates to accomodate the new import locations for the Users in Role from Airflow 2.9.0


## Checklist

### For all Pull Requests

- [ ] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [ ] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [ ] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated