### PR TITLE
fix: scheduler and triggerer probe performance for airflow <2.6.0

### DIFF
--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -149,21 +149,9 @@ spec:
                   from airflow.utils.db import create_session
                   from airflow.utils.net import get_hostname
 
-                  # heartbeat check imports
-                  try:
-                      from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
-                  except ImportError:
-                      # `SchedulerJob` is wrapped by `SchedulerJobRunner` since airflow 2.6.0
-                      from airflow.jobs.scheduler_job import SchedulerJob as SchedulerJobRunner
-
                   {{- if .Values.scheduler.livenessProbe.taskCreationCheck.enabled }}
                   {{ "" }}
                   # task creation check imports
-                  try:
-                      from airflow.jobs.local_task_job_runner import LocalTaskJobRunner
-                  except ImportError:
-                      # `LocalTaskJob` is wrapped by `LocalTaskJobRunner` since airflow 2.6.0
-                      from airflow.jobs.local_task_job import LocalTaskJob as LocalTaskJobRunner
                   from airflow.utils import timezone
                   {{- end }}
 
@@ -175,7 +163,7 @@ spec:
                       hostname = get_hostname()
                       scheduler_job = session \
                           .query(Job) \
-                          .filter_by(job_type=SchedulerJobRunner.job_type) \
+                          .filter_by(job_type="SchedulerJob") \
                           .filter_by(hostname=hostname) \
                           .order_by(Job.latest_heartbeat.desc()) \
                           .limit(1) \
@@ -204,7 +192,7 @@ spec:
                           task_job_threshold = {{ $task_job_threshold }}
                           task_job = session \
                               .query(Job) \
-                              .filter_by(job_type=LocalTaskJobRunner.job_type) \
+                              .filter_by(job_type="LocalTaskJob") \
                               .order_by(Job.id.desc()) \
                               .limit(1) \
                               .first()

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -134,19 +134,12 @@ spec:
                   from airflow.utils.db import create_session
                   from airflow.utils.net import get_hostname
 
-                  # heartbeat check imports
-                  try:
-                      from airflow.jobs.triggerer_job_runner import TriggererJobRunner
-                  except ImportError:
-                      # `TriggererJob` is wrapped by `TriggererJobRunner` since airflow 2.6.0
-                      from airflow.jobs.triggerer_job import TriggererJob as TriggererJobRunner
-
                   with create_session() as session:
                       # ensure the TriggererJob with most recent heartbeat for this `hostname` is alive
                       hostname = get_hostname()
                       triggerer_job = session \
                           .query(Job) \
-                          .filter_by(job_type=TriggererJobRunner.job_type) \
+                          .filter_by(job_type="TriggererJob") \
                           .filter_by(hostname=hostname) \
                           .order_by(Job.latest_heartbeat.desc()) \
                           .limit(1) \


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- fixes #829

## What does your PR do?

Previously, we were not correctly filtering on the `job_type` field in the liveness probes for the Scheduler and Triggerer in Airflow versions older than 2.6.0.

This caused each probe to scan the entire `job` table, which is obviously very slow!

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)