### PR TITLE
fix: set `appProtocol` on Service ports (for Istio)

### DIFF
--- a/charts/airflow/templates/_helpers/common.tpl
+++ b/charts/airflow/templates/_helpers/common.tpl
@@ -62,13 +62,26 @@ true
 {{- end -}}
 
 {{/*
-The scheme (HTTP, HTTPS) used by the webserver
+The scheme (HTTP, HTTPS) used by the webserver.
+NOTE: this is used in the liveness/readiness probes of the webserver
 */}}
 {{- define "airflow.web.scheme" -}}
 {{- if and (.Values.airflow.config.AIRFLOW__WEBSERVER__WEB_SERVER_SSL_CERT) (.Values.airflow.config.AIRFLOW__WEBSERVER__WEB_SERVER_SSL_KEY) -}}
 HTTPS
 {{- else -}}
 HTTP
+{{- end -}}
+{{- end -}}
+
+{{/*
+The app protocol used by the webserver.
+NOTE: this sets the `appProtocol` of the Service port (only important for Istio users)
+*/}}
+{{- define "airflow.web.appProtocol" -}}
+{{- if and (.Values.airflow.config.AIRFLOW__WEBSERVER__WEB_SERVER_SSL_CERT) (.Values.airflow.config.AIRFLOW__WEBSERVER__WEB_SERVER_SSL_KEY) -}}
+https
+{{- else -}}
+http
 {{- end -}}
 {{- end -}}
 

--- a/charts/airflow/templates/flower/flower-service.yaml
+++ b/charts/airflow/templates/flower/flower-service.yaml
@@ -21,6 +21,8 @@ spec:
     release: {{ .Release.Name }}
   ports:
     - name: flower
+      ## NOTE: flower always uses http (only important for Istio users)
+      appProtocol: http
       protocol: TCP
       port: {{ .Values.flower.service.externalPort }}
       {{- if and (eq .Values.flower.service.type "NodePort") (.Values.flower.service.nodePort.http) }}

--- a/charts/airflow/templates/pgbouncer/pgbouncer-service.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-service.yaml
@@ -17,6 +17,8 @@ spec:
     release: {{ .Release.Name }}
   ports:
     - name: pgbouncer
+      ## NOTE: pgbouncer should be treated as opaque TCP (only important for Istio users)
+      appProtocol: tcp
       protocol: TCP
       port: 6432
 {{- end }}

--- a/charts/airflow/templates/webserver/webserver-service.yaml
+++ b/charts/airflow/templates/webserver/webserver-service.yaml
@@ -25,6 +25,7 @@ spec:
   {{- end }}
   ports:
     - name: web
+      appProtocol: {{ include "airflow.web.appProtocol" . | quote }}
       protocol: TCP
       port: {{ .Values.web.service.externalPort | default 8080 }}
       {{- if and (eq .Values.web.service.type "NodePort") (.Values.web.service.nodePort.http) }}

--- a/charts/airflow/templates/worker/worker-service.yaml
+++ b/charts/airflow/templates/worker/worker-service.yaml
@@ -13,6 +13,9 @@ metadata:
 spec:
   ports:
     - name: worker
+      ## NOTE: the worker logs port is always http (only important for Istio users)
+      ##       https://github.com/apache/airflow/blob/2.9.0/airflow/utils/log/file_task_handler.py#L415
+      appProtocol: http
       protocol: TCP
       port: 8793
   clusterIP: None


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- fixes https://github.com/airflow-helm/charts/issues/545
- fixes https://github.com/airflow-helm/charts/issues/499
- closes https://github.com/airflow-helm/charts/pull/493
- related https://github.com/airflow-helm/charts/issues/510
- related https://github.com/airflow-helm/charts/discussions/566


## What does your PR do?

This PR sets the `appProtocol` field on all our Service ports. 

This will help users who have Istio installed on their cluster, as it will prevent [automatic protocol detection](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#automatic-protocol-selection) (which may fail in some cases).

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)