### PR TITLE
feat: add values to set init-container resources

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -225,6 +225,7 @@ Parameter | Description | Default
 `airflow.extraVolumeMounts` | extra VolumeMounts for the airflow Pods | `[]`
 `airflow.extraVolumes` | extra Volumes for the airflow Pods | `[]`
 `airflow.clusterDomain` | kubernetes cluster domain name | `cluster.local`
+`airflow.initContainers.*` | airflow init-containers | `<see values.yaml>`
 `airflow.localSettings.*` | airflow_local_settings.py | `<see values.yaml>`
 `airflow.kubernetesPodTemplate.*` | pod_template.yaml | `<see values.yaml>`
 `airflow.dbMigrations.*` | db-migrations Deployment | `<see values.yaml>`

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -60,6 +60,8 @@ EXAMPLE USAGE: {{ include "airflow.init_container.check_db" (dict "Release" .Rel
 {{- define "airflow.init_container.check_db" }}
 - name: check-db
   {{- include "airflow.image" . | indent 2 }}
+  resources:
+    {{- toYaml .Values.airflow.initContainers.checkDb.resources | nindent 4 }}
   envFrom:
     {{- include "airflow.envFrom" . | indent 4 }}
   env:
@@ -87,6 +89,8 @@ EXAMPLE USAGE: {{ include "airflow.init_container.wait_for_db_migrations" (dict 
 {{- define "airflow.init_container.wait_for_db_migrations" }}
 - name: wait-for-db-migrations
   {{- include "airflow.image" . | indent 2 }}
+  resources:
+    {{- toYaml .Values.airflow.initContainers.waitForDbMigrations.resources | nindent 4 }}
   envFrom:
     {{- include "airflow.envFrom" . | indent 4 }}
   env:
@@ -164,6 +168,8 @@ EXAMPLE USAGE: {{ include "airflow.init_container.install_pip_packages" (dict "R
 {{- define "airflow.init_container.install_pip_packages" }}
 - name: install-pip-packages
   {{- include "airflow.image" . | indent 2 }}
+  resources:
+    {{- toYaml .Values.airflow.initContainers.installPipPackages.resources | nindent 4 }}
   envFrom:
     {{- include "airflow.envFrom" . | indent 4 }}
   env:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -258,6 +258,38 @@ airflow:
   clusterDomain: "cluster.local"
 
   ########################################
+  ## CONFIGS | airflow init-containers
+  ########################################
+  ##
+  initContainers:
+    ## configs for the "check-db" init-containers
+    ##
+    checkDb:
+      ## resource requests/limits for the "check-db" init-containers
+      ## - spec for ResourceRequirements:
+      ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+      ##
+      resources: {}
+
+    ## configs for the "wait-for-db-migrations" init-containers
+    ##
+    waitForDbMigrations:
+      ## resource requests/limits for the "wait-for-db-migrations" init-containers
+      ## - spec for ResourceRequirements:
+      ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+      ##
+      resources: {}
+
+    ## configs for the "install-pip-packages" init-containers
+    ##
+    installPipPackages:
+      ## resource requests/limits for the "install-pip-packages" init-containers
+      ## - spec for ResourceRequirements:
+      ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core
+      ##
+      resources: {}
+
+  ########################################
   ## FILE | airflow_local_settings.py
   ########################################
   ##


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- fixes https://github.com/airflow-helm/charts/issues/242
- fixes https://github.com/airflow-helm/charts/issues/808
- closes https://github.com/airflow-helm/charts/pull/684
- closes https://github.com/airflow-helm/charts/pull/801

## What does your PR do?

This PR allows you to set the resource request/limits for the few remaining init-containers for which there was not already values.

This PR adds the following values:

- `airflow.initContainers.checkDb.resources` (default: `{}`)
     - Sets resources requests/limits for `check-db` init-containers
- `airflow.initContainers.waitForDbMigrations.resources` (default: `{}`)
     - Sets resources requests/limits for `wait-for-db-migrations` init-containers
- `airflow.initContainers.installPipPackages.resources` (default: `{}`)
     - Sets resources requests/limits for `install-pip-packages` init-containers

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)