### PR TITLE
feat: add `extraContainers` and `extraInitContainers` values for all components

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -252,11 +252,12 @@ Parameter | Description | Default
 `scheduler.podDisruptionBudget.*` | configs for the PodDisruptionBudget of the scheduler | `<see values.yaml>`
 `scheduler.logCleanup.*` | configs for the log-cleanup sidecar of the scheduler | `<see values.yaml>`
 `scheduler.numRuns` | the value of the `airflow --num_runs` parameter used to run the airflow scheduler | `-1`
+`scheduler.livenessProbe.*` | configs for the scheduler Pods' liveness probe | `<see values.yaml>`
 `scheduler.extraPipPackages` | extra pip packages to install in the scheduler Pods | `[]`
+`scheduler.extraContainers` | extra containers for the scheduler Pods | `[]`
+`scheduler.extraInitContainers` | extra init-containers for the scheduler Pods | `[]`
 `scheduler.extraVolumeMounts` | extra VolumeMounts for the scheduler Pods | `[]`
 `scheduler.extraVolumes` | extra Volumes for the scheduler Pods | `[]`
-`scheduler.livenessProbe.*` | configs for the scheduler Pods' liveness probe | `<see values.yaml>`
-`scheduler.extraInitContainers` | extra init containers to run in the scheduler Pods | `[]`
 
 </details>
 

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -222,6 +222,7 @@ Parameter | Description | Default
 `airflow.protectedPipPackages` | pip packages that are protected from upgrade/downgrade by `extraPipPackages` | `["apache-airflow"]`
 `airflow.extraEnv` | extra environment variables for the airflow Pods | `[]`
 `airflow.extraContainers` | extra containers for the airflow Pods | `[]`
+`airflow.extraInitContainers` | extra init-containers for the airflow Pods | `[]`
 `airflow.extraVolumeMounts` | extra VolumeMounts for the airflow Pods | `[]`
 `airflow.extraVolumes` | extra Volumes for the airflow Pods | `[]`
 `airflow.clusterDomain` | kubernetes cluster domain name | `cluster.local`

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -315,6 +315,8 @@ Parameter | Description | Default
 `workers.logCleanup.*` | configs for the log-cleanup sidecar of the worker Pods | `<see values.yaml>`
 `workers.livenessProbe.*` | configs for the worker Pods' liveness probe | `<see values.yaml>`
 `workers.extraPipPackages` | extra pip packages to install in the worker Pods | `[]`
+`workers.extraContainers` | extra containers for the worker Pods | `[]`
+`workers.extraInitContainers` | extra init-containers for the worker Pods | `[]`
 `workers.extraVolumeMounts` | extra VolumeMounts for the worker Pods | `[]`
 `workers.extraVolumes` | extra Volumes for the worker Pods | `[]`
 

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -370,7 +370,9 @@ Parameter | Description | Default
 `flower.basicAuthSecret` | the name of a pre-created secret containing the basic authentication value for flower | `""`
 `flower.basicAuthSecretKey` | the key within `flower.basicAuthSecret` containing the basic authentication string | `""`
 `flower.service.*` | configs for the Service of the flower Pods | `<see values.yaml>`
-`flower.extraPipPackages` | extra pip packages to install in the flower Pod | `[]`
+`flower.extraPipPackages` | extra pip packages to install in the flower Pods | `[]`
+`flower.extraContainers` | extra containers for the flower Pods | `[]`
+`flower.extraInitContainers` | extra init-containers for the flower Pods | `[]`
 `flower.extraVolumeMounts` | extra VolumeMounts for the flower Pods | `[]`
 `flower.extraVolumes` | extra Volumes for the flower Pods | `[]`
 

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -284,6 +284,8 @@ Parameter | Description | Default
 `web.readinessProbe.*` | configs for the web Pods' readiness probe | `<see values.yaml>`
 `web.livenessProbe.*` | configs for the web Pods' liveness probe | `<see values.yaml>`
 `web.extraPipPackages` | extra pip packages to install in the web Pods | `[]`
+`web.extraContainers` | extra containers for the web Pods | `[]`
+`web.extraInitContainers` | extra init-containers for the web Pods | `[]`
 `web.extraVolumeMounts` | extra VolumeMounts for the web Pods | `[]`
 `web.extraVolumes` | extra Volumes for the web Pods | `[]`
 

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -343,6 +343,8 @@ Parameter | Description | Default
 `triggerer.capacity` | maximum number of triggers each triggerer will run at once (sets `AIRFLOW__TRIGGERER__DEFAULT_CAPACITY`) | `1000`
 `triggerer.livenessProbe.*` | configs for the triggerer Pods' liveness probe | `<see values.yaml>`
 `triggerer.extraPipPackages` | extra pip packages to install in the triggerer Pods | `[]`
+`triggerer.extraContainers` | extra containers for the triggerer Pods | `[]`
+`triggerer.extraInitContainers` | extra init-containers for the triggerer Pods | `[]`
 `triggerer.extraVolumeMounts` | extra VolumeMounts for the triggerer Pods | `[]`
 `triggerer.extraVolumes` | extra Volumes for the triggerer Pods | `[]`
 

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -95,6 +95,9 @@ spec:
         {{- if .Values.airflow.extraInitContainers }}
         {{- toYaml .Values.airflow.extraInitContainers | nindent 8 }}
         {{- end }}
+        {{- if .Values.flower.extraInitContainers }}
+        {{- toYaml .Values.flower.extraInitContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: airflow-flower
           {{- include "airflow.image" . | indent 10 }}
@@ -160,6 +163,9 @@ spec:
         {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}
+        {{- end }}
+        {{- if .Values.flower.extraContainers }}
+        {{- toYaml .Values.flower.extraContainers | nindent 8 }}
         {{- end }}
       {{- if $volumes }}
       volumes:

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -92,6 +92,9 @@ spec:
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- if .Values.airflow.extraInitContainers }}
+        {{- toYaml .Values.airflow.extraInitContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: airflow-flower
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -99,6 +99,9 @@ spec:
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- if .Values.airflow.extraInitContainers }}
+        {{- toYaml .Values.airflow.extraInitContainers | nindent 8 }}
+        {{- end }}
         {{- if .Values.scheduler.extraInitContainers }}
         {{- toYaml .Values.scheduler.extraInitContainers | nindent 8 }}
         {{- end }}

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -240,6 +240,9 @@ spec:
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}
         {{- end }}
+        {{- if .Values.scheduler.extraContainers }}
+        {{- toYaml .Values.scheduler.extraContainers | nindent 8 }}
+        {{- end }}
       {{- if or ($volumes) (include "airflow.executor.kubernetes_like" .) }}
       volumes:
         {{- $volumes | indent 8 }}

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -91,6 +91,9 @@ spec:
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- if .Values.airflow.extraInitContainers }}
+        {{- toYaml .Values.airflow.extraInitContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: airflow-triggerer
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/triggerer/triggerer-deployment.yaml
+++ b/charts/airflow/templates/triggerer/triggerer-deployment.yaml
@@ -94,6 +94,9 @@ spec:
         {{- if .Values.airflow.extraInitContainers }}
         {{- toYaml .Values.airflow.extraInitContainers | nindent 8 }}
         {{- end }}
+        {{- if .Values.triggerer.extraInitContainers }}
+        {{- toYaml .Values.triggerer.extraInitContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: airflow-triggerer
           {{- include "airflow.image" . | indent 10 }}
@@ -168,6 +171,9 @@ spec:
         {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}
+        {{- end }}
+        {{- if .Values.triggerer.extraContainers }}
+        {{- toYaml .Values.triggerer.extraContainers | nindent 8 }}
         {{- end }}
       {{- if $volumes }}
       volumes:

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -96,6 +96,9 @@ spec:
         {{- if .Values.airflow.extraInitContainers }}
         {{- toYaml .Values.airflow.extraInitContainers | nindent 8 }}
         {{- end }}
+        {{- if .Values.web.extraInitContainers }}
+        {{- toYaml .Values.web.extraInitContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: airflow-web
           {{- include "airflow.image" . | indent 10 }}
@@ -152,6 +155,9 @@ spec:
         {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}
+        {{- end }}
+        {{- if .Values.web.extraContainers }}
+        {{- toYaml .Values.web.extraContainers | nindent 8 }}
         {{- end }}
       volumes:
         {{- $volumes | indent 8 }}

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -93,6 +93,9 @@ spec:
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- if .Values.airflow.extraInitContainers }}
+        {{- toYaml .Values.airflow.extraInitContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: airflow-web
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -99,6 +99,9 @@ spec:
         {{- if .Values.airflow.extraInitContainers }}
         {{- toYaml .Values.airflow.extraInitContainers | nindent 8 }}
         {{- end }}
+        {{- if .Values.workers.extraInitContainers }}
+        {{- toYaml .Values.workers.extraInitContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: airflow-worker
           {{- include "airflow.image" . | indent 10 }}
@@ -220,6 +223,9 @@ spec:
         {{- end }}
         {{- if .Values.airflow.extraContainers }}
         {{- toYaml .Values.airflow.extraContainers | nindent 8 }}
+        {{- end }}
+        {{- if .Values.workers.extraContainers }}
+        {{- toYaml .Values.workers.extraContainers | nindent 8 }}
         {{- end }}
       {{- if $volumes }}
       volumes:

--- a/charts/airflow/templates/worker/worker-statefulset.yaml
+++ b/charts/airflow/templates/worker/worker-statefulset.yaml
@@ -96,6 +96,9 @@ spec:
         {{- end }}
         {{- include "airflow.init_container.check_db" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
         {{- include "airflow.init_container.wait_for_db_migrations" (dict "Release" .Release "Values" .Values "volumeMounts" $volumeMounts) | indent 8 }}
+        {{- if .Values.airflow.extraInitContainers }}
+        {{- toYaml .Values.airflow.extraInitContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: airflow-worker
           {{- include "airflow.image" . | indent 10 }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -653,6 +653,18 @@ scheduler:
   ##
   extraPipPackages: []
 
+  ## extra containers for the scheduler Pods
+  ## - spec for Container:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+  ##
+  extraContainers: []
+
+  ## extra init-containers for the scheduler Pods
+  ## - spec of Container:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+  ##
+  extraInitContainers: []
+
   ## extra VolumeMounts for the scheduler Pods
   ## - spec of VolumeMount:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core
@@ -664,12 +676,6 @@ scheduler:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volume-v1-core
   ##
   extraVolumes: []
-
-  ## extra init containers to run in the scheduler Pods
-  ## - spec of Container:
-  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
-  ##
-  extraInitContainers: []
 
 ###################################
 ## COMPONENT | Airflow Webserver

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -833,6 +833,18 @@ web:
   ##
   extraPipPackages: []
 
+  ## extra containers for the web Pods
+  ## - spec for Container:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+  ##
+  extraContainers: []
+
+  ## extra init-containers for the web Pods
+  ## - spec of Container:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+  ##
+  extraInitContainers: []
+
   ## extra VolumeMounts for the web Pods
   ## - spec for VolumeMount:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1035,6 +1035,18 @@ workers:
   ##
   extraPipPackages: []
 
+  ## extra containers for the worker Pods
+  ## - spec for Container:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+  ##
+  extraContainers: []
+
+  ## extra init-containers for the worker Pods
+  ## - spec of Container:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+  ##
+  extraInitContainers: []
+
   ## extra VolumeMounts for the worker Pods
   ## - spec for VolumeMount:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1312,13 +1312,25 @@ flower:
     timeoutSeconds: 5
     failureThreshold: 6
 
-  ## extra pip packages to install in the flower Pod
+  ## extra pip packages to install in the flower Pods
   ##
   ## ____ EXAMPLE _______________
   ##   extraPipPackages:
   ##     - "SomeProject==1.0.0"
   ##
   extraPipPackages: []
+
+  ## extra containers for the flower Pods
+  ## - spec for Container:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+  ##
+  extraContainers: []
+
+  ## extra init-containers for the flower Pods
+  ## - spec of Container:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+  ##
+  extraInitContainers: []
 
   ## extra VolumeMounts for the flower Pods
   ## - spec for VolumeMount:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -237,6 +237,12 @@ airflow:
   ##
   extraContainers: []
 
+  ## extra init-containers for the airflow Pods
+  ## - spec for Container:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+  ##
+  extraInitContainers: []
+
   ## extra VolumeMounts for the airflow Pods
   ## - spec for VolumeMount:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1166,6 +1166,18 @@ triggerer:
   ##
   extraPipPackages: []
 
+  ## extra containers for the triggerer Pods
+  ## - spec for Container:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+  ##
+  extraContainers: []
+
+  ## extra init-containers for the triggerer Pods
+  ## - spec of Container:
+  ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#container-v1-core
+  ##
+  extraInitContainers: []
+
   ## extra VolumeMounts for the triggerer Pods
   ## - spec for VolumeMount:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#volumemount-v1-core


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- closes https://github.com/airflow-helm/charts/pull/651
- closes https://github.com/airflow-helm/charts/pull/788

## What does your PR do?

This PR adds values for `extraContainers` and `extraInitContainers` for all Deployments.

This PR adds the following values:

- `airflow.extraInitContainers` (default: `[]`)
- `scheduler.extraContainers` (default: `[]`)
- `web.extraContainers` (default: `[]`)
- `web.extraInitContainers` (default: `[]`)
- `workers.extraContainers` (default: `[]`)
- `workers.extraInitContainers` (default: `[]`)
- `triggerer.extraContainers` (default: `[]`)
- `triggerer.extraInitContainers` (default: `[]`)
- `flower.extraContainers` (default: `[]`)
- `flower.extraInitContainers` (default: `[]`)

## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)