### PR TITLE
fix: don't import User and Role FAB models, fixes airflow 2.9.0+

### DIFF
--- a/charts/airflow/templates/sync/_helpers/sync_users.tpl
+++ b/charts/airflow/templates/sync/_helpers/sync_users.tpl
@@ -25,18 +25,11 @@ flask_app = www_app.create_app()
 flask_appbuilder = flask_app.appbuilder
 {{- end }}
 
-# airflow moves the User and Role models around in different versions
-try:
-  # since 2.7.0
-  from airflow.auth.managers.fab.models import User, Role
-except ModuleNotFoundError:
-  try:
-    # from 2.3.0 to 2.6.3
-    from airflow.www.fab_security.sqla.models import User, Role
-  except ModuleNotFoundError:
-    # before 2.3.0
-    from flask_appbuilder.security.sqla.models import User, Role
-
+# we want type hints, but airflow keeps moving the `User` and `Role` models around
+#                                  (╯°□°)╯︵ ┻━┻
+from typing import Any
+User = Any
+Role = Any
 
 #############
 ## Classes ##


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- fixes https://github.com/airflow-helm/charts/issues/847
- closes https://github.com/airflow-helm/charts/pull/848


## What does your PR do?

I give up, I have no idea why they keep moving the FAB `User` and `Role` models around, but we don't really need to import them anyway (they were only for type hints).


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)