### PR TITLE
feat: add rbac.serviceaccounts value

### DIFF
--- a/charts/airflow/CHANGELOG.md
+++ b/charts/airflow/CHANGELOG.md
@@ -8,6 +8,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) 
 
 TBD
 
+### Added
+- You can now give the airflow ServiceAccount GET/LIST on ServiceAccount resources
+    * This is needed for `KubernetesPodOperator(service_account_name=<customServiceAccount>)`
+    * To enable, set `rbac.serviceaccounts` to `true` (Default: `false`)
+
 ## [8.9.0] - 2024-04-30
 
 > 🟨 __NOTES__ 🟨

--- a/charts/airflow/Chart.yaml
+++ b/charts/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Airflow Helm Chart (User Community) - the standard way to deploy Apache Airflow on Kubernetes with Helm
 name: airflow
-version: 8.9.0
+version: 8.10.0
 appVersion: 2.8.4
 icon: https://avatars.githubusercontent.com/u/71061241
 home: https://github.com/airflow-helm/charts/tree/main/charts/airflow

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -429,6 +429,7 @@ Parameter | Description | Default
 `rbac.create` | if Kubernetes RBAC resources are created | `true`
 `rbac.events` | if the created RBAC Role has GET/LIST on Event resources | `true`
 `rbac.secrets` | if the created RBAC Role has GET/LIST/WATCH on Secret resources | `false`
+`rbac.serviceaccounts` | if the created RBAC Role has GET/LIST on ServiceAccount resources | `false`
 
 </details>
 

--- a/charts/airflow/templates/rbac/airflow-role.yaml
+++ b/charts/airflow/templates/rbac/airflow-role.yaml
@@ -28,6 +28,15 @@ rules:
   - "list"
   - "watch"
 {{- end }}
+{{- if .Values.rbac.serviceaccounts }}
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - "get"
+  - "list"
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1771,6 +1771,11 @@ rbac:
   ##
   secrets: false
 
+  ## if the created RBAC Role has GET/LIST on ServiceAccount resources
+  ## - this is needed for KubernetesPodOperator() to use `service_account_name=<customServiceAccount>`
+  ##
+  serviceaccounts: false
+
 ###################################
 ## CONFIG | Kubernetes ServiceAccount
 ###################################


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

Fixes dags that use the KubernetesPodOperator setting `service_account_name` argument to a custom service account other than Airflow's:

```
[2024-07-01, 11:16:27 UTC] {pod.py:1107} INFO - Building pod REDACTED with labels: {'dag_id': '32.02-AgentIngest', 'task_id': 'REDACTED', 'run_id': 'scheduled__2024-07-01T1000000000-03129e074', 'kubernetes_pod_operator': 'True', 'try_number': '2'}
[2024-07-01, 11:16:28 UTC] {base.py:84} INFO - Using connection ID 'kubernetes_default' for task execution.
[2024-07-01, 11:16:28 UTC] {pod_manager.py:334} ERROR - Exception when attempting to create Namespaced Pod: {   "apiVersion": "v1",   "kind": "Pod",   [...REDACTED...]  "serviceAccountName": "mysa",     "tolerations": [],     "volumes": []   } }
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/providers/cncf/kubernetes/utils/pod_manager.py", line 329, in run_pod_async
    resp = self._client.create_namespaced_pod(
  File "/home/airflow/.local/lib/python3.10/site-packages/kubernetes/client/api/core_v1_api.py", line 7356, in create_namespaced_pod
    return self.create_namespaced_pod_with_http_info(namespace, body, **kwargs)  # noqa: E501
  File "/home/airflow/.local/lib/python3.10/site-packages/kubernetes/client/api/core_v1_api.py", line 7455, in create_namespaced_pod_with_http_info
    return self.api_client.call_api(
  File "/home/airflow/.local/lib/python3.10/site-packages/kubernetes/client/api_client.py", line 348, in call_api
    return self.__call_api(resource_path, method,
  File "/home/airflow/.local/lib/python3.10/site-packages/kubernetes/client/api_client.py", line 180, in __call_api
    response_data = self.request(
  File "/home/airflow/.local/lib/python3.10/site-packages/kubernetes/client/api_client.py", line 391, in request
    return self.rest_client.POST(url,
  File "/home/airflow/.local/lib/python3.10/site-packages/kubernetes/client/rest.py", line 279, in POST
    return self.request("POST", url,
  File "/home/airflow/.local/lib/python3.10/site-packages/kubernetes/client/rest.py", line 238, in request
    raise ApiException(http_resp=r)
kubernetes.client.exceptions.ApiException: (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Audit-Id': 'd28ba1ed-88b3-4d23-b564-57833dad63d5', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Kubernetes-Pf-Flowschema-Uid': 'd8c1c6ea-5cae-4996-8995-669952a8f74a', 'X-Kubernetes-Pf-Prioritylevel-Uid': '35d5696a-251b-4647-8347-fb0f98fea966', 'Date': 'Mon, 01 Jul 2024 11:16:28 GMT', 'Content-Length': '311'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"REDACTED\" is forbidden: error looking up service account dev/mysa: serviceaccount \"mysa\" not found","reason":"Forbidden","details":{"name":"REDACTED","kind":"pods"},"code":403}
```
**NOTE**: `HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"REDACTED\" is forbidden: error looking up service account dev/mysa: serviceaccount \"mysa\" not found","reason":"Forbidden","details":{"name":"REDACTED","kind":"pods"},"code":403}`



## What does your PR do?

Adds a `rbac.serviceaccounts` value to allow Airflow's to get/list serviceaccounts


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated