### PR TITLE
fix: properly template extraEnv values

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -224,7 +224,7 @@ Parameter | Description | Default
 `airflow.podAnnotations` | extra annotations for airflow Pods | `{}`
 `airflow.extraPipPackages` | extra pip packages to install in airflow Pods | `[]`
 `airflow.protectedPipPackages` | pip packages that are protected from upgrade/downgrade by `extraPipPackages` | `["apache-airflow"]`
-`airflow.extraEnv` | extra environment variables for the airflow Pods | `[]`
+`airflow.extraEnv` | extra environment variables for the airflow Pods (will be templated) | `[]`
 `airflow.extraContainers` | extra containers for the airflow Pods | `[]`
 `airflow.extraInitContainers` | extra init-containers for the airflow Pods | `[]`
 `airflow.extraVolumeMounts` | extra VolumeMounts for the airflow Pods | `[]`

--- a/charts/airflow/docs/faq/configuration/airflow-configs.md
+++ b/charts/airflow/docs/faq/configuration/airflow-configs.md
@@ -37,7 +37,9 @@ airflow:
 
 > 🟦 __Tip__ 🟦
 >
-> To store sensitive configs in Kubernetes secrets, you may use the `airflow.extraEnv` value.
+> To store sensitive configs in Kubernetes secrets, you may use the `airflow.extraEnv` value to mount extra environment variables
+> with the same structure as [EnvVar in ContainerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#envvar-v1-core).
+> These values will be templated by Helm, so you can use variables or template functions.
 > 
 > For example, to set `AIRFLOW__CORE__FERNET_KEY` from a Secret called `airflow-fernet-key` containing a key called `value`:
 >

--- a/charts/airflow/docs/faq/kubernetes/mount-environment-variables.md
+++ b/charts/airflow/docs/faq/kubernetes/mount-environment-variables.md
@@ -4,7 +4,7 @@
 
 # Mount Environment Variables from Secrets/ConfigMaps
 
-You may use the `airflow.extraEnv` value to mount extra environment variables with the same structure as [EnvVar in ContainerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#envvar-v1-core).
+You may use the `airflow.extraEnv` value to mount extra environment variables with the same structure as [EnvVar in ContainerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#envvar-v1-core). These values will be templated by Helm, so you can use variables or template functions.
 
 > 🟦 __Tip__ 🟦
 >
@@ -20,4 +20,13 @@ airflow:
         secretKeyRef:
           name: airflow-fernet-key
           key: value
+```
+
+Here is an example which sets `AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER` with a templated value:
+
+```yaml
+airflow:
+  extraEnv:
+    - name: AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER
+      value: "s3://{{ .Release.Namespace }}-airflow/logs"
 ```

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -624,6 +624,6 @@ EXAMPLE USAGE: {{ include "airflow.env" (dict "Release" .Release "Values" .Value
 
 {{- /* user-defined environment variables */ -}}
 {{- if .Values.airflow.extraEnv }}
-{{ toYaml .Values.airflow.extraEnv }}
+{{ tpl (toYaml .Values.airflow.extraEnv) . }}
 {{- end }}
 {{- end }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -239,7 +239,7 @@ airflow:
   protectedPipPackages:
     - "apache-airflow"
 
-  ## extra environment variables for the airflow Pods
+  ## extra environment variables for the airflow Pods (will be templated)
   ## - spec for EnvVar:
   ##   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#envvar-v1-core
   ##


### PR DESCRIPTION
## What issues does your PR fix?

https://github.com/airflow-helm/charts/issues/879

## What does your PR do?

Runs `extraEnv` values through `tpl` so users can utilize templating in their values.

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [x] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [x] CHANGELOG.md updated