### PR TITLE
fix: Remove / when repoSubPath is not defined

### DIFF
--- a/charts/airflow/templates/_helpers/common.tpl
+++ b/charts/airflow/templates/_helpers/common.tpl
@@ -89,11 +89,15 @@ http
 The path containing DAG files
 */}}
 {{- define "airflow.dags.path" -}}
-{{- if .Values.dags.gitSync.enabled -}}
-{{- printf "%s/repo/%s" (.Values.dags.path | trimSuffix "/") (.Values.dags.gitSync.repoSubPath | trimAll "/") -}}
-{{- else -}}
-{{- printf .Values.dags.path -}}
-{{- end -}}
+  {{- if .Values.dags.gitSync.enabled -}}
+    {{- if .Values.dags.gitSync.repoSubPath -}}
+      {{- printf "%s/repo/%s" (.Values.dags.path | trimSuffix "/") (.Values.dags.gitSync.repoSubPath | trimAll "/") -}}
+    {{- else -}}
+      {{- printf "%s/repo" (.Values.dags.path | trimSuffix "/") -}}
+    {{- end -}}
+  {{- else -}}
+    {{- printf "%s" (.Values.dags.path | trimSuffix "/") -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- This PR aims to fix the issue with Airflow 2.10.x where the scheduler compares the dag filelocation with the dag_folders path. The main issue is that the dags_folder setting ends up being `/opt/airflow/dags/repo/` when the repoSubPath is empty, when the correct one should be `/opt/airflow/dags/repo` without the final slash. Otherwise the DAGs will disappear from the UI 🫠 .

The airflow code messing up with us is this [one](https://github.com/apache/airflow/blob/2.10.1/airflow/dag_processing/manager.py#L531-L537).

## What does your PR do?

This PR makes the captures when the `repoSubPath` is not define in the values since the dags are already present in the root git folder


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated