### PR TITLE
feat: Update git-sync to v4.4.0

### DIFF
--- a/charts/airflow/docs/faq/configuration/airflow-plugins.md
+++ b/charts/airflow/docs/faq/configuration/airflow-plugins.md
@@ -85,7 +85,7 @@ dags:
   gitSync:
     enabled: true
     repo: "https://github.com/USERNAME/REPOSITORY.git"
-    branch: "master"
+    revision: "master"
 ```
 
 </details>

--- a/charts/airflow/docs/faq/dags/load-dag-definitions.md
+++ b/charts/airflow/docs/faq/dags/load-dag-definitions.md
@@ -44,8 +44,7 @@ dags:
     
     ## NOTE: some git providers will need an `ssh://` prefix
     repo: "git@github.com:USERNAME/REPOSITORY.git"
-    branch: "master"
-    revision: "HEAD"
+    revision: "master"
     
     ## the sub-path within your repo where dags are located
     ## NOTE: airflow will only see dags under this path, but the whole repo will still be synced
@@ -111,8 +110,7 @@ dags:
     enabled: true
     
     repo: "https://github.com/USERNAME/REPOSITORY.git"
-    branch: "master"
-    revision: "HEAD"
+    revision: "master"
     
     ## the sub-path within your repo where dags are located
     ## NOTE: airflow will only see dags under this path, but the whole repo will still be synced

--- a/charts/airflow/examples/google-gke/custom-values.yaml
+++ b/charts/airflow/examples/google-gke/custom-values.yaml
@@ -319,10 +319,9 @@ dags:
     ## the url of the git repo
     repo: "git@github.com:USERNAME/REPOSITORY.git"
 
-    ## the git branch to check out
-    branch: master
-
-    ## the git revision (tag or hash) to check out
+    ## the git revision (branch, tag, or hash) to check out
+    ## specifying "HEAD" will use the repo's default branch
+    ## when specifying a hash, it must be a full hash, and not an abbreviated form.
     revision: HEAD
 
     ## the name of a pre-created Secret with git ssh credentials

--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -246,53 +246,49 @@ EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release 
     {{- include "airflow.envFrom" . | indent 4 }}
   env:
     {{- if .sync_one_time }}
-    - name: GIT_SYNC_ONE_TIME
+    - name: GITSYNC_ONE_TIME
       value: "true"
     {{- end }}
-    - name: GIT_SYNC_ROOT
+    - name: GITSYNC_ROOT
       value: "/dags"
-    - name: GIT_SYNC_DEST
+    - name: GITSYNC_LINK
       value: "repo"
-    - name: GIT_SYNC_REPO
+    - name: GITSYNC_REPO
       value: {{ .Values.dags.gitSync.repo | quote }}
-    - name: GIT_SYNC_BRANCH
-      value: {{ .Values.dags.gitSync.branch | quote }}
-    - name: GIT_SYNC_REV
+    - name: GIT_SYNC_REF
       value: {{ .Values.dags.gitSync.revision | quote }}
-    - name: GIT_SYNC_DEPTH
+    - name: GITSYNC_DEPTH
       value: {{ .Values.dags.gitSync.depth | quote }}
-    - name: GIT_SYNC_WAIT
-      value: {{ .Values.dags.gitSync.syncWait | quote }}
-    - name: GIT_SYNC_TIMEOUT
-      value: {{ .Values.dags.gitSync.syncTimeout | quote }}
-    - name: GIT_SYNC_ADD_USER
+    - name: GITSYNC_PERIOD
+      value: "{{ .Values.dags.gitSync.syncWait }}s"
+    - name: GITSYNC_SYNC_TIMEOUT
+      value: "{{ .Values.dags.gitSync.syncTimeout }}s"
+    - name: GITSYNC_ADD_USER
       value: "true"
-    - name: GIT_SYNC_MAX_SYNC_FAILURES
+    - name: GITSYNC_MAX_FAILURES
       value: {{ .Values.dags.gitSync.maxFailures | quote }}
-    - name: GIT_SYNC_SUBMODULES
+    - name: GITSYNC_SUBMODULES
       value: {{ .Values.dags.gitSync.submodules | quote }}
     {{- if .Values.dags.gitSync.sshSecret }}
-    - name: GIT_SYNC_SSH
-      value: "true"
-    - name: GIT_SSH_KEY_FILE
+    - name: GITSYNC_SSH_KEY_FILE
       value: "/etc/git-secret/id_rsa"
     {{- end }}
     {{- if .Values.dags.gitSync.sshKnownHosts }}
-    - name: GIT_KNOWN_HOSTS
+    - name: GITSYNC_SSH_KNOWN_HOSTS
       value: "true"
-    - name: GIT_SSH_KNOWN_HOSTS_FILE
+    - name: GITSYNC_SSH_KNOWN_HOSTS_FILE
       value: "/etc/git-secret/known_hosts"
     {{- else }}
-    - name: GIT_KNOWN_HOSTS
+    - name: GITSYNC_SSH_KNOWN_HOSTS
       value: "false"
     {{- end }}
     {{- if .Values.dags.gitSync.httpSecret }}
-    - name: GIT_SYNC_USERNAME
+    - name: GITSYNC_USERNAME
       valueFrom:
         secretKeyRef:
           name: {{ .Values.dags.gitSync.httpSecret }}
           key: {{ .Values.dags.gitSync.httpSecretUsernameKey }}
-    - name: GIT_SYNC_PASSWORD
+    - name: GITSYNC_PASSWORD
       valueFrom:
         secretKeyRef:
           name: {{ .Values.dags.gitSync.httpSecret }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1525,7 +1525,7 @@ dags:
     ##
     image:
       repository: registry.k8s.io/git-sync/git-sync
-      tag: v3.6.9
+      tag: v4.4.0
       pullPolicy: IfNotPresent
       uid: 65533
       gid: 65533
@@ -1554,11 +1554,9 @@ dags:
     ##
     repoSubPath: ""
 
-    ## the git branch to check out
-    ##
-    branch: master
-
-    ## the git revision (tag or hash) to check out
+    ## the git revision (branch, tag, or hash) to check out
+    ## specifying "HEAD" will use the repo's default branch
+    ## when specifying a hash, it must be a full hash, and not an abbreviated form
     ##
     revision: HEAD
 


### PR DESCRIPTION
## What issues does your PR fix?
- #885 

## What does your PR do?
Updates git-sync image to v4.4.0 and adapts the env variables accordingly.

The changes are backwards-compatible with the exception that the `--branch` and `--rev` flags have been merged to the new `--ref` flag. This implies that `.Values.dags.gitSync.branch` and `.Values.dags.gitSync.revision` should also be merged. I have implemented it like that following [this table](https://github.com/kubernetes/git-sync/blob/master/v3-to-v4.md#sync-target---branch-and---rev-----ref).

In the docs examples I have used the branch name as the revision, because I thought people would most likely want to specify a branch instead of "HEAD" or so and they might be confused if they don't see a way to do that.

The other option would be to not merge the values and rely on:
> For backwards compatibility, git-sync will still accept the old flags and try to set --ref from them.


## Checklist

### For all Pull Requests

- [X] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [X] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [X] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [X] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated