### PR TITLE
feat: provide a better container output when "airflow check db" fails

### DIFF
--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -85,7 +85,7 @@ EXAMPLE USAGE: {{ include "airflow.init_container.check_db" (dict "Release" .Rel
     {{- if .Values.airflow.legacyCommands }}
     - "exec timeout 60s airflow checkdb"
     {{- else }}
-    - "exec timeout 60s airflow db check"
+    - "exec bash -c 'timeout 60s airflow db check; exit_code=$?; if [ $exit_code -eq 124 ]; then echo \"Database connection check timed out after 60s\"; elif [ $exit_code -ne 0 ]; then echo \"Database check failed with code $exit_code\"; fi; exit $exit_code'"
     {{- end }}
   {{- if .volumeMounts }}
   volumeMounts:


### PR DESCRIPTION
We recently had issue with `check-db` task and we found the output quite limited. I am wondering if having a dedicated log message could help.

This one liner is not the cleanest but at least we expose a message in container output.

We could even mention that the issue is with the bouncer.