### PR TITLE
feat: let user specify multiple replica count for pgbouncer

### DIFF
--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -475,6 +475,7 @@ Parameter | Description | Default
 `pgbouncer.podAnnotations` | Pod annotations for the pgbouncer Deployment | `{}`
 `pgbouncer.safeToEvict` | if we add the annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict" = "true" | `true`
 `pgbouncer.podDisruptionBudget.*` | configs for the PodDisruptionBudget of the pgbouncer | `<see values.yaml>`
+`pgbouncer.replicaCount` | Pod replication capability | `<see values.yaml>`
 `pgbouncer.livenessProbe.*` | configs for the pgbouncer Pods' liveness probe | `<see values.yaml>`
 `pgbouncer.startupProbe.*` | configs for the pgbouncer Pods' startup probe | `<see values.yaml>`
 `pgbouncer.terminationGracePeriodSeconds` | the maximum number of seconds to wait for queries upon pod termination, before force killing | `120`

--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -74,7 +74,7 @@ metadata:
   {{- toYaml .Values.pgbouncer.annotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.pgbouncer.replicaCount }}
   strategy:
     rollingUpdate:
       ## multiple pgbouncer pods can safely run concurrently

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -1951,6 +1951,10 @@ pgbouncer:
     ##
     minAvailable:
 
+  ## the number of replica count. Careful, each pgbouncer instance maintains its own connection pool
+  ##
+  replicaCount: 1
+
   ## configs for the pgbouncer Pods' liveness probe
   ##
   livenessProbe:


### PR DESCRIPTION
## What does your PR do?

We want to have more than one replica to be sure we have everything up an running, especially during deployment phase (in our case).

## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)
