### PR TITLE
fix: quote all template usage of ingress.web.host

### DIFF
--- a/charts/airflow/templates/webserver/webserver-ingress-v1beta1.yaml
+++ b/charts/airflow/templates/webserver/webserver-ingress-v1beta1.yaml
@@ -20,16 +20,16 @@ spec:
   {{- if .Values.ingress.web.tls.enabled }}
   tls:
     - hosts:
-        - {{ .Values.ingress.web.host }}
+        - {{ .Values.ingress.web.host | quote }}
       {{- if .Values.ingress.web.tls.secretName }}
       secretName: {{ .Values.ingress.web.tls.secretName }}
       {{- end }}
   {{- end }}
   {{- if .Values.ingress.web.ingressClassName }}
   ingressClassName: {{ .Values.ingress.web.ingressClassName }}
-  {{- end }}  
+  {{- end }}
   rules:
-    - host: {{ .Values.ingress.web.host }}
+    - host: {{ .Values.ingress.web.host | quote }}
       http:
         paths:
           {{- range .Values.ingress.web.precedingPaths }}

--- a/charts/airflow/templates/webserver/webserver-ingress.yaml
+++ b/charts/airflow/templates/webserver/webserver-ingress.yaml
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.ingress.web.tls.enabled }}
   tls:
     - hosts:
-        - {{ .Values.ingress.web.host }}
+        - {{ .Values.ingress.web.host | quote }}
       {{- if .Values.ingress.web.tls.secretName }}
       secretName: {{ .Values.ingress.web.tls.secretName }}
       {{- end }}
@@ -29,7 +29,7 @@ spec:
   ingressClassName: {{ .Values.ingress.web.ingressClassName }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.web.host }}
+    - host: {{ .Values.ingress.web.host | quote }}
       http:
         paths:
           {{- range .Values.ingress.web.precedingPaths }}


### PR DESCRIPTION
Signed-off-by: Keto D. Zhang <keto.zhang@gmail.com>

<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- fixes #927


## What does your PR do?

Add quotes to all template usage of `.ingress.web.host`. This fixes wildcard hostnames which aren't treated as string in YAML w/o quoting.


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated
