### PR TITLE
Change Redis repository to bitnamilegacy

### DIFF
--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -2214,7 +2214,7 @@ redis:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis
+    repository: bitnamilegacy/redis
     tag: 6.2.14-debian-12-r17
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

Builds are failing currently because bitnami/redis no longer exists. Swapping to bitnamilegacy will get builds working again, but these packages are no longer being maintained and so a more permanent solution should be setup in future


## What does your PR do?

This PR makes the following changes...


## Checklist

### For all Pull Requests

- [ ] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [ ] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [ ] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated